### PR TITLE
Fixed issue with frozen, gaseous targets. The SDTrimSP parameter tabl…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -397,13 +397,13 @@ fn main() {
                             let dy = p2.y() - particle_2.pos.y;
                             let distance_to_surface = (dx*dx + dy*dy).sqrt();
 
-                            if (distance_to_surface < estimated_range_of_recoils) & (binary_collision_result.recoil_energy > particle_2.Ec) {
+                            if (distance_to_surface < estimated_range_of_recoils) & (particle_2.E > particle_2.Ec) {
                                 particle_2.add_trajectory();
                                 particles.push(particle_2);
                             }
                         }
                     //If transferred energy > cutoff energy, add recoil to particle vector
-                } else if options.track_recoils & (binary_collision_result.recoil_energy > particle_2.Ec) {
+                } else if options.track_recoils & (particle_2.E > particle_2.Ec) {
                         particles.push(particle_2);
                     }
                 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,8 +6,8 @@ fn test_momentum_conservation() {
 
     for energy_eV in vec![1., 10., 100., 1000., 10000., 100000., 1000000., 10000000.] {
         //Aluminum
-        let m1 = 63.54*AMU;
-        let Z1 = 29.;
+        let m1 = 4.008*AMU;
+        let Z1 = 2.;
         let E1 = energy_eV*EV;
         let Ec1 = 1.*EV;
         let Es1 = 1.*EV;
@@ -16,8 +16,8 @@ fn test_momentum_conservation() {
         let z1 = 0.;
 
         //Aluminum
-        let m2 = 63.54;
-        let Z2 = 29.;
+        let m2 = 6.941;
+        let Z2 = 3.;
         let Ec2 = 1.;
         let Es2 = 1.;
 


### PR DESCRIPTION
…e had a bulk binding energy greater than the cutoff energy for oxygen. In the recoil generation step, it was not checked if the recoil would have negative energy before it was added to the particle list.