### PR TITLE
Surface refraction fix

### DIFF
--- a/src/bca.rs
+++ b/src/bca.rs
@@ -250,7 +250,8 @@ fn distance_of_closest_approach(particle_1: &particle::Particle, particle_2: &pa
             return Ok(x0);
         }
     }
-    return Err(anyhow!("Exceeded maximum number of Newton-Raphson iterations, {}. x0: {}; Error: {}; Tolerance: {}", options.max_iterations, x0, err, options.tolerance));
+    return Err(anyhow!("Numerical error: exceeded maximum number of Newton-Raphson iterations, {}. x0: {}; Error: {}; Tolerance: {}",
+        options.max_iterations, x0, err, options.tolerance));
 }
 
 pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &particle::Particle, binary_collision_geometry: &BinaryCollisionGeometry, options: &Options) -> BinaryCollisionResult {
@@ -283,7 +284,7 @@ pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &
                 KR_C => vec![ 0.7887, 0.01166, 00.006913, 17.16, 10.79 ],
                 ZBL => vec![ 0.99229, 0.011615, 0.0071222, 9.3066, 14.813 ],
                 TRIDYN => vec![1.0144, 0.235809, 0.126, 69350., 83550.], //Undocumented Tridyn constants
-                _ => panic!("Unimplemented interaction potential {} for MAGIC algorithm.",  options.interaction_potential)
+                _ => panic!("Input error: unimplemented interaction potential {} for MAGIC algorithm.",  options.interaction_potential)
             };
             let c = vec![ 0.190945, 0.473674, 0.335381, 0.0 ];
             let d = vec![ -0.278544, -0.637174, -1.919249, 0.0 ];
@@ -304,7 +305,8 @@ pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &
             let ctheta2 = (b + rho/a + delta)/(x0 + rho/a);
             2.*((b + rho/a + delta)/(x0 + rho/a)).acos()
         },
-        _ => panic!("Unimplemented scattering integral: {}. Use 0: Mendenhall-Weller Quadrature 1: MAGIC Algorithm",  options.scattering_integral)
+        _ => panic!("Input error: unimplemented scattering integral: {}. Use 0: Mendenhall-Weller Quadrature 1: MAGIC Algorithm",
+            options.scattering_integral)
     };
 
     //See Eckstein 1991 for details on center of mass and lab frame angles
@@ -355,7 +357,7 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
                     ZBL => 0.20162,
                     LENZ_JENSEN => 0.206,
                     TRIDYN => 0.278544,
-                    _ => panic!("Unimplemented interaction potential. Use 0: MOLIERE 1: KR_C 2: ZBL")
+                    _ => panic!("Input error: unimplemented interaction potential. Use 0: MOLIERE 1: KR_C 2: ZBL")
                 };
 
                 d1*d1/2./PI*electronic_stopping_powers[strong_collision_index]*(-d1*xi).exp()/a/a*ck
@@ -373,7 +375,7 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
                     ZBL => 0.20162,
                     LENZ_JENSEN => 0.206,
                     TRIDYN => 0.278544,
-                    _ => panic!("Unimplemented interaction potential. Use 0: MOLIERE 1: KR_C 2: ZBL")
+                    _ => panic!("Input error: unimplemented interaction potential. Use 0: MOLIERE 1: KR_C 2: ZBL")
                 };
                 let delta_energy_local = d1*d1/2./PI*electronic_stopping_powers[strong_collision_index]*(-d1*xi).exp()/a/a;
                 let delta_energy_nonlocal = electronic_stopping_powers.iter().zip(n).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled*ck;
@@ -381,7 +383,7 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
                 (0.5*delta_energy_local + 0.5*delta_energy_nonlocal)*ck
             },
             //Panic at unimplemented electronic stopping mode
-            _ => panic!("Unimplemented electronic stopping mode. Use 0: Biersack-Varelas 1: Lindhard-Scharff 2: Oen-Robinson 3: Equipartition")
+            _ => panic!("Input error: unimplemented electronic stopping mode. Use 0: Biersack-Varelas 1: Lindhard-Scharff 2: Oen-Robinson 3: Equipartition")
         };
 
         particle_1.E += -delta_energy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,11 +262,8 @@ fn main() {
         let (cosx, cosy, cosz) = particle_parameters.dir[particle_index];
         for sub_particle_index in 0..N_ {
 
-            //Surface refraction
-            let Es = particle_parameters.Es[particle_index];
+            let E_old = E*energy_unit;
             let E_new = E*energy_unit + Es*energy_unit;
-
-            let delta_theta = particle::refraction_angle(cosx, E*energy_unit, (E + Es)*energy_unit);
 
             //Add new particle to particle vector
             particles.push(particle::Particle::new(
@@ -274,6 +271,8 @@ fn main() {
                 x*length_unit, y*length_unit, z*length_unit,
                 cosx, cosy, cosz, true, options.track_trajectories
             ));
+            //Surface refraction
+            let delta_theta = particle::refraction_angle(cosx, E_old, E_new);
             particle::rotate_particle(particles.last_mut().unwrap(), delta_theta, 0.);
         }
     }

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -36,6 +36,8 @@ pub struct Particle {
 }
 impl Particle {
     pub fn new(m: f64, Z: f64, E: f64, Ec: f64, Es: f64, x: f64, y: f64, z: f64, dirx: f64, diry: f64, dirz: f64, incident: bool, track_trajectories: bool) -> Particle {
+        let dir_mag = (dirx*dirx + diry*diry + dirz*dirz).sqrt();
+
         Particle {
             m: m,
             Z: Z,
@@ -43,7 +45,7 @@ impl Particle {
             Ec: Ec,
             Es: Es,
             pos: Vector::new(x, y, z),
-            dir: Vector::new(dirx, diry, dirz),
+            dir: Vector::new(dirx/dir_mag, diry/dir_mag, dirz/dir_mag),
             pos_old: Vector::new(x, y, z),
             pos_origin: Vector::new(x, y, z),
             asympototic_deflection: 0.,

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -109,3 +109,11 @@ pub fn particle_advance(particle_1: &mut particle::Particle, mfp: f64, asympotot
 
     return distance_traveled;
 }
+
+pub fn refraction_angle(costheta: f64, energy_old: f64, energy_new: f64) -> f64 {
+    let sintheta0 = (1. - costheta*costheta).sqrt();
+    let sintheta1 = sintheta0*(energy_old/energy_new).sqrt();
+    let delta_theta = sintheta1.asin() - sintheta0.asin();
+    let sign = -costheta.signum();
+    return sign*delta_theta;
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,67 @@
 use super::*;
 
 #[test]
+fn test_surface_refraction() {
+    let mass = 1.;
+    let Z = 1.;
+    let E = 10.*EV;
+    let Ec = 1.*EV;
+    let Es = 5.76*EV;
+    let x = 0.;
+    let y = 0.;
+    let z = 0.;
+    let cosx = 1./(2.0_f64).sqrt();
+    let cosy = 1./(2.0_f64).sqrt();
+    let cosz = 0.;
+    let mut particle_1 = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false);
+
+    //Test particle entering material and gaining energy
+
+    //Eckstein's formulation for particle entering surface
+    let cosx_new = ((E*cosx*cosx + Es)/(E + Es)).sqrt();
+    let sinx = (1. - cosx*cosx).sqrt();
+    let sinx_new = (1. - cosx_new*cosx_new).sqrt();
+    let cosy_new = cosy*sinx_new/sinx;
+    let cosz_new = cosz*sinx_new/sinx;
+    let dir_mag = (cosx_new*cosx_new + cosy_new*cosy_new + cosz_new*cosz_new).sqrt();
+    println!("dir_mag: {}", dir_mag);
+    let cosx_new = cosx_new/dir_mag;
+    let cosy_new = cosy_new/dir_mag;
+    let cosz_new = cosz_new/dir_mag;
+
+    let delta_theta = particle::refraction_angle(cosx, E, E + Es);
+    particle::rotate_particle(&mut particle_1, delta_theta, 0.);
+
+    println!("{} {} {}", cosx, cosy, cosz);
+    println!("{} {} {}", cosx_new, cosy_new, cosz_new);
+    println!("{} {} {}", particle_1.dir.x, particle_1.dir.y, particle_1.dir.z);
+    println!();
+
+    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-6));
+    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-6));
+    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-6));
+
+    //Test particle leaving material and losing energy
+
+    let cosx_new = ((particle_1.E*particle_1.dir.x*particle_1.dir.x - Es)/(particle_1.E - Es)).sqrt();
+    let sinx = (1. - particle_1.dir.x*particle_1.dir.x).sqrt();
+    let sinx_new = (1. - cosx_new*cosx_new).sqrt();
+    let cosy_new = particle_1.dir.y*sinx_new/sinx;
+    let cosz_new = particle_1.dir.z*sinx_new/sinx;
+
+    println!("{} {} {}", particle_1.dir.x, particle_1.dir.y, particle_1.dir.z);
+    let delta_theta = particle::refraction_angle(particle_1.dir.x, particle_1.E, particle_1.E - Es);
+    particle::rotate_particle(&mut particle_1, delta_theta, 0.);
+
+    println!("{} {} {}", cosx_new, cosy_new, cosz_new);
+    println!("{} {} {}", particle_1.dir.x, particle_1.dir.y, particle_1.dir.z);
+
+    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-6));
+    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-6));
+    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-6));
+}
+
+#[test]
 fn test_momentum_conservation() {
 
     for energy_eV in vec![1., 10., 100., 1000., 10000., 100000., 1000000., 10000000.] {
@@ -73,7 +134,7 @@ fn test_momentum_conservation() {
                         mean_free_path_model: LIQUID,
                         interaction_potential: potential,
                         scattering_integral: scattering_integral,
-                        tolerance: 1E-9,
+                        tolerance: 1E-12,
                         max_iterations: 100,
                     };
 
@@ -125,9 +186,9 @@ fn test_momentum_conservation() {
                     println!("Z: {} {} {}% Error", initial_momentum.z/ANGSTROM/AMU, final_momentum.z/ANGSTROM/AMU, 100.*(final_momentum.z - initial_momentum.z)/initial_momentum.magnitude());
                     println!();
 
-                    approx_eq!(f64, initial_momentum.x/ANGSTROM/AMU, final_momentum.x/ANGSTROM/AMU, epsilon = 1e-12);
-                    approx_eq!(f64, initial_momentum.y/ANGSTROM/AMU, final_momentum.y/ANGSTROM/AMU, epsilon = 1e-12);
-                    approx_eq!(f64, initial_momentum.z/ANGSTROM/AMU, final_momentum.z/ANGSTROM/AMU, epsilon = 1e-12);
+                    assert!(approx_eq!(f64, initial_momentum.x, final_momentum.x, epsilon = 1E-12));
+                    assert!(approx_eq!(f64, initial_momentum.y, final_momentum.y, epsilon = 1E-12));
+                    assert!(approx_eq!(f64, initial_momentum.z, final_momentum.z, epsilon = 1E-12));
 
                     assert!(!particle_1.E.is_nan());
                     assert!(!particle_2.E.is_nan());
@@ -160,19 +221,19 @@ fn test_rotate_particle() {
 
     //Check that rotation in 2D works
     particle::rotate_particle(&mut particle, psi, phi);
-    assert!(approx_eq!(f64, particle.dir.x, 0., epsilon = 1e-9), "particle.dir.x: {} Should be ~0.", particle.dir.x);
-    assert!(approx_eq!(f64, particle.dir.y, 1., epsilon = 1e-9), "particle.dir.y: {} Should be ~1.", particle.dir.y);
+    assert!(approx_eq!(f64, particle.dir.x, 0., epsilon = 1E-12), "particle.dir.x: {} Should be ~0.", particle.dir.x);
+    assert!(approx_eq!(f64, particle.dir.y, 1., epsilon = 1E-12), "particle.dir.y: {} Should be ~1.", particle.dir.y);
 
     //Check that rotating back by negative psi returns to the previous values
     particle::rotate_particle(&mut particle, -psi, phi);
-    assert!(approx_eq!(f64, particle.dir.x, cosx, epsilon = 1e-9), "particle.dir.x: {} Should be ~{}", particle.dir.x, cosx);
-    assert!(approx_eq!(f64, particle.dir.y, cosy, epsilon = 1e-9), "particle.dir.y: {} Should be ~{}", particle.dir.y, cosy);
+    assert!(approx_eq!(f64, particle.dir.x, cosx, epsilon = 1E-12), "particle.dir.x: {} Should be ~{}", particle.dir.x, cosx);
+    assert!(approx_eq!(f64, particle.dir.y, cosy, epsilon = 1E-12), "particle.dir.y: {} Should be ~{}", particle.dir.y, cosy);
 
     //Check that azimuthal rotation by 180 degrees works correctly
     let phi = PI;
     particle::rotate_particle(&mut particle, psi, phi);
-    assert!(approx_eq!(f64, particle.dir.x, 1., epsilon = 1e-9), "particle.dir.x: {} Should be ~1.", particle.dir.x);
-    assert!(approx_eq!(f64, particle.dir.y, 0., epsilon = 1e-9), "particle.dir.y: {} Should be ~0.", particle.dir.y);
+    assert!(approx_eq!(f64, particle.dir.x, 1., epsilon = 1E-12), "particle.dir.x: {} Should be ~1.", particle.dir.x);
+    assert!(approx_eq!(f64, particle.dir.y, 0., epsilon = 1E-12), "particle.dir.y: {} Should be ~0.", particle.dir.y);
 
     //Check that particle direction vector remains normalized following rotations
     assert!(approx_eq!(f64, particle.dir.x.powf(2.) + particle.dir.y.powf(2.) + particle.dir.z.powf(2.), 1.), "Particle direction not normalized.");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -38,9 +38,9 @@ fn test_surface_refraction() {
     println!("{} {} {}", particle_1.dir.x, particle_1.dir.y, particle_1.dir.z);
     println!();
 
-    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-6));
-    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-6));
-    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-6));
+    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-9));
+    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-9));
+    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-9));
 
     //Test particle leaving material and losing energy
 
@@ -57,9 +57,9 @@ fn test_surface_refraction() {
     println!("{} {} {}", cosx_new, cosy_new, cosz_new);
     println!("{} {} {}", particle_1.dir.x, particle_1.dir.y, particle_1.dir.z);
 
-    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-6));
-    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-6));
-    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-6));
+    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-9));
+    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-9));
+    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-9));
 }
 
 #[test]


### PR DESCRIPTION
Fix to surface refraction. Surface refraction spun out into separate function for calculating the refraction angle, correctly handling sign of cos(theta). Added test that compares to Eckstein's formulation - surface refraction passes test for particles both leaving and entering surface.