### PR TITLE
Surface refraction fix; order of operations fix.

### DIFF
--- a/run_rustbca.py
+++ b/run_rustbca.py
@@ -212,9 +212,9 @@ tungsten = {
     'Z': 74,
     'm': 183.84,
     'n': 6.306E28,
-    'Es': 11.75,
+    'Es': 8.79,
     'Eb': 0.,
-    'Ec': 5.,
+    'Ec': 6.,
     'Q': 0.72,
     'W': 2.14,
     's': 2.8
@@ -295,24 +295,24 @@ def main(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_, theta,
     material_parameters = {
         'energy_unit': 'EV',
         'mass_unit': 'AMU',
-        'Eb': Eb,
-        'Es': Esb,
-        'Ec': Ecb,
-        'n': n,
-        'Z': Zb,
-        'm': Mb,
+        'Eb': [Eb],
+        'Es': [Esb],
+        'Ec': [Ecb],
+        'n': [n],
+        'Z': [Zb],
+        'm': [Mb],
         'electronic_stopping_correction_factor': ck
     }
 
-    #dx = 2.*n**(-1./3.)/np.sqrt(2.*np.pi)/MICRON
+    dx = 2.*n**(-1./3.)/np.sqrt(2.*np.pi)/MICRON
     #dx = n**(-1./3.)*np.cos(theta)/MICRON
-    dx = 0.
+    #dx = 0.
 
     minx, miny, maxx, maxy = 0.0, -thickness/2., depth, thickness/2.
     surface = box(minx, miny, maxx, maxy)
 
     energy_surface = surface.buffer(dx, cap_style=2, join_style=2)
-    simulation_surface = surface.buffer(2.*dx, cap_style=2, join_style=2)
+    simulation_surface = surface.buffer(10.*dx, cap_style=2, join_style=2)
 
     geometry = {
         'length_unit': 'MICRON',
@@ -327,7 +327,7 @@ def main(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_, theta,
     if random:
         positions = [(-dx, np.random.uniform(-thickness/2., thickness/2.), 0.) for _ in range(N)]
     else:
-        positions = [(-dx, 0., 0.) for _ in range(N)]
+        positions = [(0., 0., 0.) for _ in range(N)]
 
     particle_parameters = {
         'length_unit': 'MICRON',
@@ -1389,13 +1389,14 @@ def benchmark():
 
     N = 1
     N_ = 10000
-    angles = np.array([0.001])
+    angles = np.array([0.0001])
     thickness = 1
     depth = 1
     #energies = [1000.]
     #energies = [20.0]
     #energies = [0.1, 1., 10., 50.]
-    energies = np.round(np.logspace(1., 4, 20), 1)
+    energies = np.round(np.logspace(1., 3, 6), 1)
+    #energies = [55.]
     #energies = [100.]
     #energies = np.array([1E7])
     #energies = [1000.]
@@ -1411,8 +1412,8 @@ def benchmark():
     mfp_model = LIQUID
     do_trajectory_plot = False
     run_magic = False
-    interaction_potential = TRIDYN
-    scattering_integral = MAGIC
+    interaction_potential = KR_C
+    scattering_integral = QUADRATURE
 
     #os.system('rm *.png')
     os.system('rm *.output')
@@ -1578,7 +1579,7 @@ def benchmark():
                     plot_distributions(rustbca_name, ftridyn_name, beam, target,
                         file_num=1, incident_energy=energy, incident_angle=theta,
                         plot_2d_reflected_contours=False,
-                        plot_reflected_energies_by_number_collisions=True,
+                        plot_reflected_energies_by_number_collisions=False,
                         plot_scattering_energy_curve=True)
                     if do_trajectory_plot: do_plots(rustbca_name, file_num=str(1), symmetric=False, thickness=thickness, depth=depth)
                     #breakpoint()

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -250,8 +250,10 @@ fn distance_of_closest_approach(particle_1: &particle::Particle, particle_2: &pa
             return Ok(x0);
         }
     }
-    return Err(anyhow!("Numerical error: exceeded maximum number of Newton-Raphson iterations, {}. x0: {}; Error: {}; Tolerance: {}",
-        options.max_iterations, x0, err, options.tolerance));
+    return Err(anyhow!("Numerical error: exceeded maximum number of Newton-Raphson iterations, {}. E: {}; x, y, z: ({},{},{}); x0: {}; Error: {}; Tolerance: {}",
+        options.max_iterations, E0,
+        particle_1.pos.x/ANGSTROM, particle_1.pos.y/ANGSTROM, particle_1.pos.z/ANGSTROM,
+        x0, err, options.tolerance));
 }
 
 pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &particle::Particle, binary_collision_geometry: &BinaryCollisionGeometry, options: &Options) -> BinaryCollisionResult {
@@ -332,7 +334,7 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
     let ck = material.electronic_stopping_correction_factor;
 
     //if material.inside_energy_barrier(x, y) {
-    if material.inside_energy_barrier(x, y) {
+    if material.inside(x, y) {
 
         let electronic_stopping_powers = material.electronic_stopping_cross_sections(particle_1, options.electronic_stopping_mode);
         let n = material.n.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,13 +267,13 @@ fn main() {
 
             //Add new particle to particle vector
             particles.push(particle::Particle::new(
-                m*mass_unit, Z, E_new, Ec*energy_unit, Es*energy_unit,
+                m*mass_unit, Z, E_old, Ec*energy_unit, Es*energy_unit,
                 x*length_unit, y*length_unit, z*length_unit,
                 cosx, cosy, cosz, true, options.track_trajectories
             ));
             //Surface refraction
-            let delta_theta = particle::refraction_angle(cosx, E_old, E_new);
-            particle::rotate_particle(particles.last_mut().unwrap(), delta_theta, 0.);
+            //let delta_theta = particle::refraction_angle(cosx, E_old, E_new);
+            //particle::rotate_particle(particles.last_mut().unwrap(), delta_theta, 0.);
         }
     }
 
@@ -347,7 +347,7 @@ fn main() {
                     &binary_collision_geometries[k], &options);
 
                 //If recoil location is inside, proceed with binary collision loop
-                if material.inside(particle_2.pos.x, particle_2.pos.y) {
+                if material.inside(particle_2.pos.x, particle_2.pos.y) & material.inside_energy_barrier(particle_1.pos.x, particle_1.pos.y) {
 
                     //Determine scattering angle from binary collision
                     let binary_collision_result = bca::calculate_binary_collision(&particle_1,


### PR DESCRIPTION
Fix for surface refraction issue; particle leaving condition now set when it leaves the simulation boundary, not when it leaves the energy barrier. Crucial for fixing this issue was recognizing the order of operations bug which was advancing particles according to the next set of directions as opposed to the current one, leading to strange behavior at the boundary.