### PR TITLE
Command line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,14 @@ anyhow = "1.0"
 hdf5 = {version = "0.6.1", optional = true}
 rayon = "1.3.1"
 rcpr = { git = "https://github.com/drobnyjt/rcpr", branch= "master", optional = true}
-#rcpr = { path = "../rcpr"}#, branch= "master"}
 indicatif = {version="*", features=["rayon"]}
 itertools = ""
 
 [profile.release]
 lto = "fat"
 codegen-units = 1
-target-cpu = "native"
 opt-level = 3
-debug = true
+debug = false
 
 [features]
 hdf5_input = ["hdf5"]

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -3,176 +3,167 @@ use super::*;
 const LENNARD_JONES_EPSILON: f64 = 0.343*EV;
 pub const LENNARD_JONES_SIGMA: f64 = 1.*ANGSTROM;
 
-pub fn interaction_potential(r: f64, a: f64, Za: f64, Zb: f64, interaction_potential: i32) -> f64 {
+pub fn interaction_potential(r: f64, a: f64, Za: f64, Zb: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE | KR_C | LENZ_JENSEN | ZBL => {
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::ZBL | InteractionPotential::TRIDYN => {
             screened_coulomb(r, a, Za, Zb, interaction_potential)
         },
-        LENNARD_JONES_12_6 => {
+        InteractionPotential::LENNARD_JONES_12_6 => {
             let epsilon = LENNARD_JONES_EPSILON;
             let sigma = LENNARD_JONES_SIGMA;
             lennard_jones(r, sigma, epsilon)
         },
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
     }
 }
 
-pub fn energy_threshold_single_root(interaction_potential: i32) -> f64 {
+pub fn energy_threshold_single_root(interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential{
-        LENNARD_JONES_12_6 => 4./5.*LENNARD_JONES_EPSILON*1E9,
-        MOLIERE | KR_C | LENZ_JENSEN | ZBL => 0.,
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
+        InteractionPotential::LENNARD_JONES_12_6 => 4./5.*LENNARD_JONES_EPSILON*1E9,
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::ZBL | InteractionPotential::TRIDYN => 0.,
     }
 }
 
-fn doca_function(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: i32) -> f64 {
+fn doca_function(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //Nonlinear equation to determine distance of closest approach
     return x0 - interactions::phi(x0, interaction_potential)/reduced_energy - beta*beta/x0;
 }
 
-fn diff_doca_function(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: i32) -> f64 {
+fn diff_doca_function(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //First differential of distance of closest approach function for N-R solver
     return beta*beta/x0/x0 - interactions::dphi(x0, interaction_potential)/reduced_energy + 1.
 }
 
-fn doca_function_transformed(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: i32) -> f64 {
+fn doca_function_transformed(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //Singularity free version of doca function
     return x0*x0 - x0*interactions::phi(x0, interaction_potential)/reduced_energy - beta*beta;
 }
 
-fn diff_doca_function_transformed(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: i32) -> f64 {
+fn diff_doca_function_transformed(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //First differential of distance of closest approach function for N-R solver
     return 2.*x0 - interactions::phi(x0, interaction_potential)/reduced_energy
 }
 
-pub fn distance_of_closest_approach_function(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: i32) -> f64 {
+pub fn distance_of_closest_approach_function(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE | KR_C | LENZ_JENSEN | ZBL => {
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::ZBL | InteractionPotential::TRIDYN => {
             let a: f64 = interactions::screening_length(Za, Zb, interaction_potential);
             let reduced_energy: f64 = LINDHARD_REDUCED_ENERGY_PREFACTOR*a/Za/Zb*relative_energy;
             let beta: f64 = impact_parameter/a;
             doca_function(r/a, beta, reduced_energy, interaction_potential)
 
         },
-        LENNARD_JONES_12_6 => {
+        InteractionPotential::LENNARD_JONES_12_6 => {
             let epsilon = LENNARD_JONES_EPSILON;
             let sigma = LENNARD_JONES_SIGMA;
             doca_lennard_jones(r, impact_parameter, relative_energy, sigma, epsilon)
         },
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
     }
 }
 
-pub fn distance_of_closest_approach_function_singularity_free(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: i32) -> f64 {
+pub fn distance_of_closest_approach_function_singularity_free(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: InteractionPotential) -> f64 {
     if r.is_nan() {
-        panic!("r is nan")
+        panic!("Numerical error: r is NaN in distance of closest approach function. Check Rootfinder.")
     }
     match interaction_potential {
-        MOLIERE | KR_C | LENZ_JENSEN | ZBL => {
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::ZBL | InteractionPotential::TRIDYN => {
             let a: f64 = interactions::screening_length(Za, Zb, interaction_potential);
             let reduced_energy: f64 = LINDHARD_REDUCED_ENERGY_PREFACTOR*a/Za/Zb*relative_energy;
             let beta: f64 = impact_parameter/a;
             doca_function_transformed(r/a, beta, reduced_energy, interaction_potential)
         },
-        LENNARD_JONES_12_6 => {
+        InteractionPotential::LENNARD_JONES_12_6 => {
             let epsilon = LENNARD_JONES_EPSILON;
             let sigma = LENNARD_JONES_SIGMA;
             doca_lennard_jones(r, impact_parameter, relative_energy, sigma, epsilon)
         },
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
     }
 }
 
-pub fn scaling_function(r: f64, a: f64, interaction_potential: i32) -> f64 {
+pub fn scaling_function(r: f64, a: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE | KR_C | LENZ_JENSEN | ZBL => {
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::ZBL | InteractionPotential::TRIDYN => {
             1./(1. + (r/a).powf(2.))
         },
-        LENNARD_JONES_12_6 => {
+        InteractionPotential::LENNARD_JONES_12_6 => {
             let n = 11.;
             1./(1. + (r/LENNARD_JONES_SIGMA).powf(n))
         },
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
     }
 }
 
-pub fn diff_distance_of_closest_approach_function(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: i32) -> f64 {
+pub fn diff_distance_of_closest_approach_function(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE | KR_C | LENZ_JENSEN |ZBL => {
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN |InteractionPotential::ZBL | InteractionPotential::TRIDYN => {
             let a: f64 = interactions::screening_length(Za, Zb, interaction_potential);
             //let reduced_energy: f64 = LINDHARD_REDUCED_ENERGY_PREFACTOR*a*Mb/(Ma+Mb)/Za/Zb*E0;
             let reduced_energy: f64 = LINDHARD_REDUCED_ENERGY_PREFACTOR*a/Za/Zb*relative_energy;
             let beta: f64 = impact_parameter/a;
             diff_doca_function(r/a, beta, reduced_energy, interaction_potential)
         },
-        LENNARD_JONES_12_6 => {
+        InteractionPotential::LENNARD_JONES_12_6 => {
             let epsilon = LENNARD_JONES_EPSILON;
             let sigma = LENNARD_JONES_SIGMA;
             diff_doca_lennard_jones(r, impact_parameter, relative_energy, sigma, epsilon)
         },
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
     }
 }
 
-pub fn diff_distance_of_closest_approach_function_singularity_free(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: i32) -> f64 {
+pub fn diff_distance_of_closest_approach_function_singularity_free(r: f64, a: f64, Za: f64, Zb: f64, relative_energy: f64, impact_parameter: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE | KR_C | LENZ_JENSEN |ZBL => {
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::ZBL | InteractionPotential::TRIDYN => {
             let a: f64 = interactions::screening_length(Za, Zb, interaction_potential);
             //let reduced_energy: f64 = LINDHARD_REDUCED_ENERGY_PREFACTOR*a*Mb/(Ma+Mb)/Za/Zb*E0;
             let reduced_energy: f64 = LINDHARD_REDUCED_ENERGY_PREFACTOR*a/Za/Zb*relative_energy;
             let beta: f64 = impact_parameter/a;
             diff_doca_function_transformed(r/a, beta, reduced_energy, interaction_potential)
         },
-        LENNARD_JONES_12_6 => {
+        InteractionPotential::LENNARD_JONES_12_6 => {
             let epsilon = LENNARD_JONES_EPSILON;
             let sigma = LENNARD_JONES_SIGMA;
             diff_doca_lennard_jones(r, impact_parameter, relative_energy, sigma, epsilon)
         },
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
     }
 }
 
-pub fn screened_coulomb(r: f64, a: f64, Za: f64, Zb: f64, interaction_potential: i32) -> f64 {
+pub fn screened_coulomb(r: f64, a: f64, Za: f64, Zb: f64, interaction_potential: InteractionPotential) -> f64 {
     Za*Zb*Q*Q/4./PI/EPS0/r*phi(r/a, interaction_potential)
 }
 
-pub fn phi(xi: f64, interaction_potential: i32) -> f64 {
+pub fn phi(xi: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE => moliere(xi),
-        KR_C => kr_c(xi),
-        ZBL => zbl(xi),
-        LENZ_JENSEN => lenz_jensen(xi),
-        TRIDYN => kr_c(xi),
-        _ => panic!("Input error: unimplemented screened coulomb potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN", interaction_potential)
+        InteractionPotential::MOLIERE => moliere(xi),
+        InteractionPotential::KR_C => kr_c(xi),
+        InteractionPotential::ZBL => zbl(xi),
+        InteractionPotential::LENZ_JENSEN => lenz_jensen(xi),
+        InteractionPotential::TRIDYN => kr_c(xi),
+        _ => panic!("Input error: Screened Coulomb cannot be used with {}", interaction_potential)
     }
 }
 
-pub fn dphi(xi: f64, interaction_potential: i32) -> f64 {
+pub fn dphi(xi: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE => diff_moliere(xi),
-        KR_C => diff_kr_c(xi),
-        ZBL => diff_zbl(xi),
-        LENZ_JENSEN => diff_lenz_jensen(xi),
-        TRIDYN => diff_kr_c(xi),
-        _ => panic!("Input error: unimplemented screened coulomb potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN", interaction_potential)
+        InteractionPotential::MOLIERE => diff_moliere(xi),
+        InteractionPotential::KR_C => diff_kr_c(xi),
+        InteractionPotential::ZBL => diff_zbl(xi),
+        InteractionPotential::LENZ_JENSEN => diff_lenz_jensen(xi),
+        InteractionPotential::TRIDYN => diff_kr_c(xi),
+        _ => panic!("Input error: Screened Coulomb cannot be used with {}", interaction_potential)
     }
 }
 
-pub fn screening_length(Za: f64, Zb: f64, interaction_potential: i32) -> f64 {
+pub fn screening_length(Za: f64, Zb: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
         //ZBL screening length, Eckstein (4.1.8)
-        ZBL => 0.88534*A0/(Za.powf(0.23) + Zb.powf(0.23)),
+        InteractionPotential::ZBL => 0.88534*A0/(Za.powf(0.23) + Zb.powf(0.23)),
         //Lindhard/Firsov screening length, Eckstein (4.1.5)
-        MOLIERE | KR_C | LENZ_JENSEN => 0.8853*A0*(Za.sqrt() + Zb.sqrt()).powf(-2./3.),
-        LENNARD_JONES_12_6 => 0.8853*A0*(Za.sqrt() + Zb.sqrt()).powf(-2./3.),
-        _ => panic!("Input error: unimplemented screened coulomb potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN", interaction_potential)
+        InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::TRIDYN => 0.8853*A0*(Za.sqrt() + Zb.sqrt()).powf(-2./3.),
+        InteractionPotential::LENNARD_JONES_12_6 => 0.8853*A0*(Za.sqrt() + Zb.sqrt()).powf(-2./3.),
     }
 }
 
-pub fn polynomial_coefficients(relative_energy: f64, impact_parameter: f64, interaction_potential: i32) -> Vec<f64> {
+pub fn polynomial_coefficients(relative_energy: f64, impact_parameter: f64, interaction_potential: InteractionPotential) -> Vec<f64> {
     match interaction_potential {
-
-        LENNARD_JONES_12_6 => {
+        InteractionPotential::LENNARD_JONES_12_6 => {
             let epsilon = LENNARD_JONES_EPSILON;
             let sigma = LENNARD_JONES_SIGMA;
             vec![1., 0., -impact_parameter.powf(2.), 0., 0., 0., 4.*epsilon*sigma.powf(6.)/relative_energy, 0., 0., 0., 0., 0., -4.*epsilon*sigma.powf(12.)/relative_energy]
@@ -225,14 +216,13 @@ fn diff_lenz_jensen(xi: f64) -> f64 {
      -0.206*0.01018*(-0.206*xi).exp() -0.3876*0.24330*(-0.3876*xi).exp() -1.038*0.7466*(-1.038*xi).exp()
 }
 
-pub fn first_screening_radius(interaction_potential: i32) -> f64 {
+pub fn first_screening_radius(interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
-        MOLIERE => 0.3,
-        KR_C => 0.278544,
-        ZBL => 0.20162,
-        LENZ_JENSEN => 0.206,
-        TRIDYN => 0.278544,
-        LENNARD_JONES_12_6 => 1.,
-        _ => panic!("Input error: unimplemented interaction potential: {}, Use 0: MOLIERE 1: KR_C 2: ZBL 3: LENZ_JENSEN 4: LENNARD_JONES_12_6", interaction_potential)
+        InteractionPotential::MOLIERE => 0.3,
+        InteractionPotential::KR_C => 0.278544,
+        InteractionPotential::ZBL => 0.20162,
+        InteractionPotential::LENZ_JENSEN => 0.206,
+        InteractionPotential::TRIDYN => 0.278544,
+        InteractionPotential::LENNARD_JONES_12_6 => 1.,
     }
 }

--- a/src/material.rs
+++ b/src/material.rs
@@ -200,7 +200,7 @@ impl Material {
         panic!("Input error: method choose() operation failed to choose a valid species. Check densities.");
     }
 
-    pub fn electronic_stopping_cross_sections(&self, particle_1: &super::particle::Particle, electronic_stopping_mode: i32) -> Vec<f64> {
+    pub fn electronic_stopping_cross_sections(&self, particle_1: &super::particle::Particle, electronic_stopping_mode: ElectronicStoppingMode) -> Vec<f64> {
 
         let E = particle_1.E;
         let Ma = particle_1.m;
@@ -239,15 +239,13 @@ impl Material {
 
             let stopping_power = match electronic_stopping_mode {
                 //Biersack-Varelas Interpolation
-                INTERPOLATED => 1./(1./S_high + 1./S_low),
+                ElectronicStoppingMode::INTERPOLATED => 1./(1./S_high + 1./S_low),
                 //Oen-Robinson
-                LOW_ENERGY_LOCAL => S_low,
+                ElectronicStoppingMode::LOW_ENERGY_LOCAL => S_low,
                 //Lindhard-Scharff
-                LOW_ENERGY_NONLOCAL => S_low,
+                ElectronicStoppingMode::LOW_ENERGY_NONLOCAL => S_low,
                 //Lindhard-Scharff and Oen-Robinson, using Lindhard Equipartition
-                LOW_ENERGY_EQUIPARTITION => S_low,
-                //Panic at unimplemented electronic stopping mode
-                _ => panic!("Input error: unimplemented electronic stopping mode. Use 0: Biersack-Varelas 1: Lindhard-Scharff 2: Oen-Robinson 3: Equipartition")
+                ElectronicStoppingMode::LOW_ENERGY_EQUIPARTITION => S_low,
             };
 
             stopping_powers.push(stopping_power);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -278,7 +278,7 @@ fn test_momentum_conservation() {
                         let initial_momentum = mom1_0.add(&mom2_0);
 
                         let binary_collision_result = bca::calculate_binary_collision(&particle_1,
-                            &particle_2, &binary_collision_geometries[0], &options);
+                            &particle_2, &binary_collision_geometries[0], &options).unwrap();
 
                         println!("E_recoil: {} eV Psi: {} rad Psi_recoil: {} rad", binary_collision_result.recoil_energy/EV,
                             binary_collision_result.psi,


### PR DESCRIPTION
All integer flags for controlling code have been replaced with enums. That way, the input file can have "NEWTON" instead of 0, etc. It removes a lot of uncertainty and unnecessary panics throughout the code - if given an input that is not valid member of an enum for one of those options, the code will panic when the input file is read instead of deeper in the code.