### PR TITLE
Fancy enums

### DIFF
--- a/src/material.rs
+++ b/src/material.rs
@@ -13,6 +13,7 @@ pub struct MaterialParameters {
     pub n: Vec<f64>,
     pub Z: Vec<f64>,
     pub m: Vec<f64>,
+    pub interaction_index: Vec<usize>,
     pub electronic_stopping_correction_factor: f64,
     pub energy_barrier_thickness: f64
 }
@@ -24,6 +25,7 @@ pub struct Material {
     pub Eb: Vec<f64>,
     pub Es: Vec<f64>,
     pub Ec: Vec<f64>,
+    pub interaction_index: Vec<usize>,
     pub electronic_stopping_correction_factor: f64,
     pub mesh_2d: mesh::Mesh2D,
     pub energy_barrier_thickness: f64
@@ -66,6 +68,7 @@ impl Material {
             Eb: material_parameters.Eb.iter().map(|&i| i*energy_unit).collect(),
             Es: material_parameters.Es.iter().map(|&i| i*energy_unit).collect(),
             Ec: material_parameters.Ec.iter().map(|&i| i*energy_unit).collect(),
+            interaction_index: material_parameters.interaction_index,
             electronic_stopping_correction_factor: material_parameters.electronic_stopping_correction_factor,
             mesh_2d: mesh::Mesh2D::new(mesh_2d_input),
             energy_barrier_thickness: material_parameters.energy_barrier_thickness*length_unit
@@ -191,13 +194,13 @@ impl Material {
         return min_Ec;
     }
 
-    pub fn choose(&self, x: f64, y: f64) -> (usize, f64, f64, f64, f64) {
+    pub fn choose(&self, x: f64, y: f64) -> (usize, f64, f64, f64, f64, usize) {
         let random_number: f64 = rand::random::<f64>();
         let cumulative_concentrations = self.get_cumulative_concentrations(x, y);
 
         for (component_index, cumulative_concentration) in cumulative_concentrations.iter().enumerate() {
             if random_number < *cumulative_concentration {
-                return (component_index, self.Z[component_index], self.m[component_index], self.Ec[component_index], self.Es[component_index]);
+                return (component_index, self.Z[component_index], self.m[component_index], self.Ec[component_index], self.Es[component_index], self.interaction_index[component_index]);
             }
         }
         panic!("Input error: method choose() operation failed to choose a valid species. Check densities.");

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -14,6 +14,7 @@ pub struct ParticleParameters {
     pub Es: Vec<f64>,
     pub pos: Vec<(f64, f64, f64)>,
     pub dir: Vec<(f64, f64, f64)>,
+    pub interaction_index: Vec<usize>
 }
 
 #[derive(Clone, PartialEq, Debug, Copy)]
@@ -30,7 +31,8 @@ pub struct ParticleInput {
     pub z: f64,
     pub ux: f64,
     pub uy: f64,
-    pub uz: f64
+    pub uz: f64,
+    pub interaction_index: usize,
 }
 
 #[derive(Clone)]
@@ -54,6 +56,7 @@ pub struct Particle {
     pub track_trajectories: bool,
     pub number_collision_events: usize,
     pub backreflected: bool,
+    pub interaction_index: usize,
 }
 impl Particle {
     pub fn from_input(input: ParticleInput, options: &Options) -> Particle {
@@ -82,11 +85,12 @@ impl Particle {
             trajectory: vec![Vector4::new(input.E, input.x, input.y, input.z)],
             track_trajectories: options.track_trajectories,
             number_collision_events: 0,
-            backreflected: false
+            backreflected: false,
+            interaction_index: input.interaction_index,
         }
     }
 
-    pub fn new(m: f64, Z: f64, E: f64, Ec: f64, Es: f64, x: f64, y: f64, z: f64, dirx: f64, diry: f64, dirz: f64, incident: bool, track_trajectories: bool) -> Particle {
+    pub fn new(m: f64, Z: f64, E: f64, Ec: f64, Es: f64, x: f64, y: f64, z: f64, dirx: f64, diry: f64, dirz: f64, incident: bool, track_trajectories: bool, interaction_index: usize) -> Particle {
         let dir_mag = (dirx*dirx + diry*diry + dirz*dirz).sqrt();
 
         Particle {
@@ -108,7 +112,8 @@ impl Particle {
             trajectory: vec![Vector4::new(E, x, y, z)],
             track_trajectories,
             number_collision_events: 0,
-            backreflected: false
+            backreflected: false,
+            interaction_index,
         }
     }
     pub fn add_trajectory(&mut self) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,7 +16,7 @@ fn test_surface_binding_energy_barrier() {
     let cosx = 1./(2.0_f64).sqrt();
     let cosy = 1./(2.0_f64).sqrt();
     let cosz = 0.;
-    let mut particle_1 = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false);
+    let mut particle_1 = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false, 0);
 
     let material_parameters = material::MaterialParameters{
         energy_unit: "EV".to_string(),
@@ -27,6 +27,7 @@ fn test_surface_binding_energy_barrier() {
         n: vec![6E28, 6E28],
         Z: vec![29., 1.],
         m: vec![63.54, 1.0008],
+        interaction_index: vec![0, 0],
         electronic_stopping_correction_factor: 0.0,
         energy_barrier_thickness: 10.
     };
@@ -119,7 +120,7 @@ fn test_surface_refraction() {
     let cosx = 1./(2.0_f64).sqrt();
     let cosy = 1./(2.0_f64).sqrt();
     let cosz = 0.;
-    let mut particle_1 = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false);
+    let mut particle_1 = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false, 0);
 
     //Test particle entering material and gaining energy
 
@@ -209,6 +210,7 @@ fn test_momentum_conservation() {
             n: vec![6.026E28],
             Z: vec![Z2],
             m: vec![m2],
+            interaction_index: vec![0],
             electronic_stopping_correction_factor: 0.0,
             energy_barrier_thickness: 0.
         };
@@ -232,7 +234,7 @@ fn test_momentum_conservation() {
 
                         println!("Case: {} {} {} {}", energy_eV, high_energy_free_flight_paths, potential, scattering_integral);
 
-                        let mut particle_1 = particle::Particle::new(m1, Z1, E1, Ec1, Es1, x1, y1, z1, cosx, cosy, cosz, false, false);
+                        let mut particle_1 = particle::Particle::new(m1, Z1, E1, Ec1, Es1, x1, y1, z1, cosx, cosy, cosz, false, false, 0);
 
                         let options = Options {
                             name: "test".to_string(),
@@ -245,12 +247,12 @@ fn test_momentum_conservation() {
                             high_energy_free_flight_paths: high_energy_free_flight_paths,
                             electronic_stopping_mode: ElectronicStoppingMode::INTERPOLATED,
                             mean_free_path_model: MeanFreePathModel::LIQUID,
-                            interaction_potential: potential,
-                            scattering_integral: scattering_integral,
+                            interaction_potential: vec![vec![potential]],
+                            scattering_integral: vec![vec![scattering_integral]],
                             num_threads: 1,
                             num_chunks: 1,
                             use_hdf5: false,
-                            root_finder: root_finder,
+                            root_finder: vec![vec![root_finder]],
                         };
 
                         let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material_1, &options);
@@ -333,7 +335,7 @@ fn test_rotate_particle() {
     let psi = -PI/4.;
     let phi = 0.;
 
-    let mut particle = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false);
+    let mut particle = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false, 0);
 
     //Check that rotation in 2D works
     particle::rotate_particle(&mut particle, psi, phi);
@@ -372,7 +374,7 @@ fn test_particle_advance() {
     let mfp = 1.;
     let asymptotic_deflection = 0.5;
 
-    let mut particle = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false);
+    let mut particle = particle::Particle::new(mass, Z, E, Ec, Es, x, y, z, cosx, cosy, cosz, false, false, 0);
 
     let distance_traveled = particle::particle_advance(&mut particle, mfp, asymptotic_deflection);
 
@@ -403,12 +405,12 @@ fn test_quadrature() {
         high_energy_free_flight_paths: false,
         electronic_stopping_mode: ElectronicStoppingMode::INTERPOLATED,
         mean_free_path_model: MeanFreePathModel::LIQUID,
-        interaction_potential: InteractionPotential::KR_C,
-        scattering_integral: ScatteringIntegral::MENDENHALL_WELLER,
+        interaction_potential:  vec![vec![InteractionPotential::KR_C]],
+        scattering_integral: vec![vec![ScatteringIntegral::MENDENHALL_WELLER]],
         num_threads: 1,
         num_chunks: 1,
         use_hdf5: false,
-        root_finder: Rootfinder::NEWTON{max_iterations: 100, tolerance: 1E-14},
+        root_finder: vec![vec![Rootfinder::NEWTON{max_iterations: 100, tolerance: 1E-14}]],
     };
 
     let x0_newton = bca::newton_rootfinder(Za, Zb, Ma, Mb, E0, p, InteractionPotential::KR_C, 100, 1E-3).unwrap();


### PR DESCRIPTION
This version allows for multiple interactions. For example, in a He on B4C situation, He-B can use a Lennard-Jones potential, B-B can use a Kr-C potential, B-C can use a ZBL potential, etc.

This requires the user to specify the interaction, scattering integral, rootfidner triplet through three matrices in the input file.

Also, this version uses enums that allow for compression of input.toml. For example, "NEWTON" is replaced with "NEWTON"={max_iterations=100, tolerance=1E-6}, allowing those options to be removed from the [options] section of the input file.