### PR TITLE
Openblas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ anyhow = "1.0.32"
 hdf5 = {version = "0.7.0", optional = true}
 rayon = "1.4.0"
 openblas-src = {version  = "0.9", optional = true}
-rcpr = { path = "../rcpr", optional = true}
+netlib-src = {version  = "0.8", optional = true}
+intel-mkl-src = {version = "0.6.0+mkl2020.1", optional = true}
+rcpr = { git = "https://github.com/drobnyjt/rcpr", optional = true}
 indicatif = {version="*", features=["rayon"]}
-itertools = ""
+itertools = "0.9.0"
 
 [profile.release]
 lto = "fat"
@@ -29,4 +31,6 @@ debug = true
 
 [features]
 hdf5_input = ["hdf5"]
-cpr_rootfinder = ["rcpr", "openblas-src"]
+cpr_rootfinder_openblas = ["rcpr", "openblas-src"]
+cpr_rootfinder_netlib = ["rcpr", "netlib-src"]
+cpr_rootfinder_intel_mkl = ["rcpr", "intel-mkl-src"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2018"
 name="rustBCA"
 
 [dependencies]
-rand = "0.7"
-geo = "0.12.2"
-serde = { version = "1", features = ["derive"] }
-toml = "0.5"
-float-cmp = "0.5.2"
-anyhow = "1.0"
-hdf5 = {version = "0.6.1", optional = true}
-rayon = "1.3.1"
-rcpr = { git = "https://github.com/drobnyjt/rcpr", branch= "master", optional = true}
-#rcpr = { path = "../rcpr", optional = true}
+rand = "0.7.3"
+geo = "0.14.2"
+serde = { version = "1.0.116", features = ["derive"] }
+toml = "0.5.6"
+float-cmp = "0.8.0"
+anyhow = "1.0.32"
+hdf5 = {version = "0.7.0", optional = true}
+rayon = "1.4.0"
+openblas-src = {version  = "0.9", optional = true}
+rcpr = { path = "../rcpr", optional = true}
 indicatif = {version="*", features=["rayon"]}
 itertools = ""
 
@@ -25,8 +25,8 @@ itertools = ""
 lto = "fat"
 codegen-units = 1
 opt-level = 3
-debug = false
+debug = true
 
 [features]
 hdf5_input = ["hdf5"]
-cpr_rootfinder = ["rcpr"]
+cpr_rootfinder = ["rcpr", "openblas-src"]

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -1,7 +1,7 @@
 use super::*;
 use geo::{Closest};
 
-#[cfg(feature = "cpr_rootfinder")]
+    #[cfg(any(feature = "cpr_rootfinder_openblas", feature = "cpr_rootfinder_netlib", feature = "cpr_rootfinder_intel_mkl"))]
 use rcpr::chebyshev::*;
 
 pub struct BinaryCollisionGeometry {
@@ -360,7 +360,7 @@ fn distance_of_closest_approach(particle_1: &particle::Particle, particle_2: &pa
     let interaction_potential = options.interaction_potential[particle_1.interaction_index][particle_2.interaction_index];
     let root_finder = if relative_energy < interactions::energy_threshold_single_root(interaction_potential) {options.root_finder[particle_1.interaction_index][particle_2.interaction_index]} else {Rootfinder::NEWTON{max_iterations: 100, tolerance: 1E-6}};
 
-    #[cfg(feature = "cpr_rootfinder")]
+    #[cfg(any(feature = "cpr_rootfinder_openblas", feature = "cpr_rootfinder_netlib", feature = "cpr_rootfinder_intel_mkl"))]
     match root_finder {
         Rootfinder::POLYNOMIAL{complex_threshold} => polynomial_rootfinder(Za, Zb, Ma, Mb, E0, p, interaction_potential, complex_threshold)
             .with_context(|| "Numerical error: polynomial rootfinder failed.")
@@ -373,7 +373,7 @@ fn distance_of_closest_approach(particle_1: &particle::Particle, particle_2: &pa
             .unwrap(),
     }
 
-    #[cfg(not(feature = "cpr_rootfinder"))]
+    #[cfg(not(any(feature = "cpr_rootfinder_openblas", feature = "cpr_rootfinder_netlib", feature = "cpr_rootfinder_intel_mkl")))]
     match root_finder {
         Rootfinder::NEWTON{max_iterations, tolerance} => newton_rootfinder(Za, Zb, Ma, Mb, E0, p, interaction_potential, max_iterations, tolerance)
             .with_context(|| "Numerical error: Newton-Raphson rootfinder failed.")
@@ -502,7 +502,7 @@ fn scattering_integral_gauss_legendre(impact_parameter: f64, relative_energy: f6
         .unwrap()).sum::<f64>()
 }
 
-#[cfg(feature = "cpr_rootfinder")]
+    #[cfg(any(feature = "cpr_rootfinder_openblas", feature = "cpr_rootfinder_netlib", feature = "cpr_rootfinder_intel_mkl"))]
 pub fn polynomial_rootfinder(Za: f64, Zb: f64, Ma: f64, Mb: f64, E0: f64, impact_parameter: f64,
     interaction_potential: InteractionPotential, polynom_complex_threshold: f64) -> Result<f64, anyhow::Error> {
 
@@ -523,7 +523,7 @@ pub fn polynomial_rootfinder(Za: f64, Zb: f64, Ma: f64, Mb: f64, E0: f64, impact
     }
 }
 
-#[cfg(feature = "cpr_rootfinder")]
+    #[cfg(any(feature = "cpr_rootfinder_openblas", feature = "cpr_rootfinder_netlib", feature = "cpr_rootfinder_intel_mkl"))]
 pub fn cpr_rootfinder(Za: f64, Zb: f64, Ma: f64, Mb: f64, E0: f64, impact_parameter: f64,
     interaction_potential: InteractionPotential, n0: usize, nmax: usize, epsilon: f64,
     complex_threshold: f64, truncation_threshold: f64, far_from_zero: f64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,13 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-//extern crate blas;
+#[cfg(feature = "cpr_rootfinder_openblas")]
 extern crate openblas_src;
+#[cfg(feature = "cpr_rootfinder_netlib")]
+extern crate netlib_src;
+#[cfg(feature = "cpr_rootfinder_intel_mkl")]
+extern crate intel_mkl_src;
+
 
 use std::{env, fmt};
 use std::mem::discriminant;
@@ -323,7 +328,7 @@ fn main() {
     for ((interaction_potentials, scattering_integrals), root_finders) in options.interaction_potential.clone().iter().zip(options.scattering_integral.clone()).zip(options.root_finder.clone()) {
         for ((interaction_potential, scattering_integral), root_finder) in interaction_potentials.iter().zip(scattering_integrals).zip(root_finders) {
 
-            if cfg!(not(feature="cpr_rootfinder")) {
+            if cfg!(not(any(feature="cpr_rootfinder_openblas", feature="cpr_rootfinder_netlib", feature="cpr_rootfinder_intel_mkl",))) {
                 assert!( match root_finder {
                     Rootfinder::POLYNOMIAL{..} => false,
                     Rootfinder::CPR{..} => false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
+//extern crate blas;
+extern crate openblas_src;
+
 use std::{env, fmt};
 use std::mem::discriminant;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -416,7 +416,7 @@ fn test_quadrature() {
     let x0_newton = bca::newton_rootfinder(Za, Zb, Ma, Mb, E0, p, InteractionPotential::KR_C, 100, 1E-12).unwrap();
 
     //If cpr_rootfinder is enabled, compare Newton to CPR - they should be nearly identical
-    #[cfg(feature = "cpr_rootfinder")]
+    #[cfg(any(feature = "cpr_rootfinder_openblas", feature = "cpr_rootfinder_netlib", feature = "cpr_rootfinder_intel_mkl"))]
     if let Ok(x0_cpr) = bca::cpr_rootfinder(Za, Zb, Ma, Mb, E0, p, InteractionPotential::KR_C, 2, 1000, 1E-13, 1E-16, 1E-18, 1E6, 1E-18, 10.) {
         println!("CPR: {} Newton: {}", x0_cpr, x0_newton);
         assert!(approx_eq!(f64, x0_newton, x0_cpr, epsilon=1E-3));


### PR DESCRIPTION
This version separates out the external dependencies for rcpr in a nicer way.

The user chooses the appropraite backend (netlib, openblas, intel-mkl) by building with one of these statements:

```
cargo build --features cpr_rootfinder_openblas
cargo build --features cpr_rootfinder_netlib
cargo build --features cpr_rootfinder_intel_mkl

```

And the code does the rest. I have gotten openblas and netlib up and running on Linux and WSL, but intel-mkl eludes me still.