### PR TITLE
Coulomb

### DIFF
--- a/src/bca.rs
+++ b/src/bca.rs
@@ -401,9 +401,12 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
         particle_1.E = 0.;
     }
 
+
+
     let x = particle_1.pos.x;
     let y = particle_1.pos.y;
     let ck = material.electronic_stopping_correction_factor;
+
     if material.inside(x, y) {
 
         let interaction_potential = options.interaction_potential[particle_1.interaction_index][material.interaction_index[strong_collision_index]];
@@ -428,6 +431,10 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
         if particle_1.E < 0. {
             particle_1.E = 0.;
         }
+
+        particle_1.energy_loss(recoil_energy, delta_energy);
+    } else if recoil_energy > 0. {
+        particle_1.energy_loss(recoil_energy, 0.);
     }
 }
 

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -457,7 +457,10 @@ pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &
     }
 
     //See Eckstein 1991 for details on center of mass and lab frame angles
-    let asympototic_deflection = x0*a*(theta/2.).sin();
+    let asympototic_deflection = match interaction_potential {
+        InteractionPotential::COULOMB{..} => 0.,
+        _ => x0*a*(theta/2.).sin()
+    };
     let psi = (theta.sin().atan2(Ma/Mb + theta.cos())).abs();
     let psi_recoil = (theta.sin().atan2(1. - theta.cos())).abs();
     let recoil_energy = 4.*(Ma*Mb)/(Ma + Mb).powf(2.)*E0*(theta/2.).sin().powf(2.);

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -17,6 +17,9 @@ pub fn interaction_potential(r: f64, a: f64, Za: f64, Zb: f64, interaction_poten
         InteractionPotential::WW => {
             tungsten_tungsten_cubic_spline(r)
         }
+        InteractionPotential::COULOMB{Za, Zb} => {
+            coulomb(r, Za, Zb)
+        }
     }
 }
 
@@ -25,6 +28,7 @@ pub fn energy_threshold_single_root(interaction_potential: InteractionPotential)
         InteractionPotential::LENNARD_JONES_12_6{..} | InteractionPotential::LENNARD_JONES_65_6{..} => f64::INFINITY,
         InteractionPotential::MORSE{..} => f64::INFINITY,
         InteractionPotential::WW => f64::INFINITY,
+        InteractionPotential::COULOMB{..} => f64::INFINITY,
         InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::ZBL | InteractionPotential::TRIDYN => 0.,
     }
 }
@@ -69,7 +73,8 @@ pub fn distance_of_closest_approach_function(r: f64, a: f64, Za: f64, Zb: f64, r
         },
         InteractionPotential::WW => {
             doca_tungsten_tungsten_cubic_spline(r, impact_parameter, relative_energy)
-        }
+        },
+        InteractionPotential::COULOMB{..} => panic!("Coulombic potential cannot be used with rootfinder.")
     }
 }
 
@@ -95,7 +100,8 @@ pub fn distance_of_closest_approach_function_singularity_free(r: f64, a: f64, Za
         },
         InteractionPotential::WW => {
             doca_tungsten_tungsten_cubic_spline(r, impact_parameter, relative_energy)
-        }
+        },
+        InteractionPotential::COULOMB{..} => panic!("Coulombic potential cannot be used with rootfinder.")
     }
 }
 
@@ -117,7 +123,8 @@ pub fn scaling_function(r: f64, a: f64, interaction_potential: InteractionPotent
         }
         InteractionPotential::WW => {
             1.
-        }
+        },
+        InteractionPotential::COULOMB{..} => panic!("Coulombic potential cannot be used with rootfinder.")
     }
 }
 
@@ -169,6 +176,10 @@ pub fn screened_coulomb(r: f64, a: f64, Za: f64, Zb: f64, interaction_potential:
     Za*Zb*Q*Q/4./PI/EPS0/r*phi(r/a, interaction_potential)
 }
 
+pub fn coulomb(r: f64, Za: f64, Zb: f64) -> f64 {
+    return Za*Zb*Q*Q/4./PI/EPS0/r;
+}
+
 pub fn phi(xi: f64, interaction_potential: InteractionPotential) -> f64 {
     match interaction_potential {
         InteractionPotential::MOLIERE => moliere(xi),
@@ -199,6 +210,7 @@ pub fn screening_length(Za: f64, Zb: f64, interaction_potential: InteractionPote
         InteractionPotential::MOLIERE | InteractionPotential::KR_C | InteractionPotential::LENZ_JENSEN | InteractionPotential::TRIDYN | InteractionPotential::WW => 0.8853*A0*(Za.sqrt() + Zb.sqrt()).powf(-2./3.),
         InteractionPotential::LENNARD_JONES_12_6{..} | InteractionPotential::LENNARD_JONES_65_6{..} => 0.8853*A0*(Za.sqrt() + Zb.sqrt()).powf(-2./3.),
         InteractionPotential::MORSE{D, alpha, r0} => alpha,
+        InteractionPotential::COULOMB{Za: Z1, Zb: Z2} => 0.88534*A0/(Z1.powf(0.23) + Z2.powf(0.23)),
     }
 }
 
@@ -359,5 +371,6 @@ pub fn first_screening_radius(interaction_potential: InteractionPotential) -> f6
         InteractionPotential::LENNARD_JONES_65_6{..} => 1.,
         InteractionPotential::MORSE{..} => 1.,
         InteractionPotential::WW => 1.,
+        InteractionPotential::COULOMB{..} => 0.3,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -671,13 +671,15 @@ fn main() {
                     ).expect(format!("Output error: could not write to {}trajectories.output.", options.name).as_str());
                 }
 
-                for energy_loss in particle.energies {
-                    writeln!(
-                        energy_loss_file_stream, "{},{},{},{},{},{},{}",
-                        particle.m/mass_unit, particle.Z,
-                        energy_loss.En/energy_unit, energy_loss.Ee/energy_unit,
-                        energy_loss.x/length_unit, energy_loss.y/length_unit, energy_loss.z/length_unit,
-                    ).expect(format!("Output error: could not write to {}energy_loss.output.", options.name).as_str());
+                if particle.incident {
+                    for energy_loss in particle.energies {
+                        writeln!(
+                            energy_loss_file_stream, "{},{},{},{},{},{},{}",
+                            particle.m/mass_unit, particle.Z,
+                            energy_loss.En/energy_unit, energy_loss.Ee/energy_unit,
+                            energy_loss.x/length_unit, energy_loss.y/length_unit, energy_loss.z/length_unit,
+                        ).expect(format!("Output error: could not write to {}energy_loss.output.", options.name).as_str());
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,8 @@ pub enum InteractionPotential {
     LENNARD_JONES_12_6 {sigma: f64, epsilon: f64},
     LENNARD_JONES_65_6 {sigma: f64, epsilon: f64},
     MORSE{D: f64, alpha: f64, r0: f64},
-    WW
+    WW,
+    COULOMB{Za: f64, Zb: f64}
 }
 
 impl fmt::Display for InteractionPotential {
@@ -123,7 +124,8 @@ impl fmt::Display for InteractionPotential {
             InteractionPotential::LENNARD_JONES_12_6{sigma, epsilon} => write!(f, "Lennard-Jones 12-6 Potential with sigma = {} A, epsilon = {} eV", sigma/ANGSTROM, epsilon/EV),
             InteractionPotential::LENNARD_JONES_65_6{sigma, epsilon} => write!(f, "Lennard-Jones 6.5-6 Potential with sigma = {} A, epsilon = {} eV", sigma/ANGSTROM, epsilon/EV),
             InteractionPotential::MORSE{D, alpha, r0} => write!(f, "Morse potential with D = {} eV, alpha = {} 1/A, and r0 = {} A", D/EV, alpha*ANGSTROM, r0/ANGSTROM),
-            InteractionPotential::WW => write!(f, "W-W cubic spline interaction potential.")
+            InteractionPotential::WW => write!(f, "W-W cubic spline interaction potential."),
+            InteractionPotential::COULOMB{Za, Zb} => write!(f, "Coulombic interaction with Za = {} and Zb = {}", Za, Zb)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,27 @@ impl Vector4 {
     }
 }
 
+#[derive(Clone)]
+pub struct EnergyLoss {
+    En: f64,
+    Ee: f64,
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+impl EnergyLoss {
+    fn new(Ee: f64, En: f64, x: f64, y: f64, z: f64) -> EnergyLoss {
+        EnergyLoss {
+            En,
+            Ee,
+            x,
+            y,
+            z
+        }
+    }
+}
+
 #[derive(Deserialize)]
 pub struct Input {
     options: Options,
@@ -551,6 +572,15 @@ fn main() {
         .unwrap();
     let mut displacements_file_stream = BufWriter::with_capacity(options.stream_size, displacements_file);
 
+    let energy_loss_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(format!("{}{}", options.name, "energy_loss.output"))
+        .context("Could not open output file.")
+        .unwrap();
+    let mut energy_loss_file_stream = BufWriter::with_capacity(options.stream_size, energy_loss_file);
+
     println!("Processing {} ions...", particle_input_array.len());
 
     let total_count: u64 = particle_input_array.len() as u64;
@@ -639,6 +669,15 @@ fn main() {
                         particle.m/mass_unit, particle.Z, pos.E/energy_unit,
                         pos.x/length_unit, pos.y/length_unit, pos.z/length_unit,
                     ).expect(format!("Output error: could not write to {}trajectories.output.", options.name).as_str());
+                }
+
+                for energy_loss in particle.energies {
+                    writeln!(
+                        energy_loss_file_stream, "{},{},{},{},{},{},{}",
+                        particle.m/mass_unit, particle.Z,
+                        energy_loss.En/energy_unit, energy_loss.Ee/energy_unit,
+                        energy_loss.x/length_unit, energy_loss.y/length_unit, energy_loss.z/length_unit,
+                    ).expect(format!("Output error: could not write to {}energy_loss.output.", options.name).as_str());
                 }
             }
         }

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -54,6 +54,7 @@ pub struct Particle {
     pub incident: bool,
     pub first_step: bool,
     pub trajectory: Vec<Vector4>,
+    pub energies: Vec<EnergyLoss>,
     pub track_trajectories: bool,
     pub number_collision_events: usize,
     pub backreflected: bool,
@@ -85,6 +86,7 @@ impl Particle {
             incident: true,
             first_step: true,
             trajectory: vec![Vector4::new(input.E, input.x, input.y, input.z)],
+            energies: vec![],
             track_trajectories: options.track_trajectories,
             number_collision_events: 0,
             backreflected: false,
@@ -113,6 +115,7 @@ impl Particle {
             incident,
             first_step: incident,
             trajectory: vec![Vector4::new(E, x, y, z)],
+            energies: vec![EnergyLoss::new(0., 0., x, y, z)],
             track_trajectories,
             number_collision_events: 0,
             backreflected: false,
@@ -122,6 +125,12 @@ impl Particle {
     pub fn add_trajectory(&mut self) {
         if self.track_trajectories {
             self.trajectory.push(Vector4 {E: self.E, x: self.pos.x, y: self.pos.y, z: self.pos.z});
+        }
+    }
+
+    pub fn energy_loss(&mut self, En: f64, Ee: f64) {
+        if self.track_trajectories {
+            self.energies.push(EnergyLoss {Ee, En, x: self.pos.x, y: self.pos.y, z: self.pos.z});
         }
     }
 


### PR DESCRIPTION
This branch adds a Coulombic interaction, which is still in testing but appears to be working, and a new output file. This file, energy_loss.output, tracks the energy loss over a particle's trajectory and contains the following in each row:

`m, Z, nuclear energy loss, electronic energy loss, x, y, z`