### PR TITLE
Added three surface binding modes. Current behavior can be replciated…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,8 @@ pub struct Options {
     num_threads: usize,
     num_chunks: u64,
     use_hdf5: bool,
+    track_displacements: bool,
+    track_energy_losses: bool,
 }
 
 fn main() {
@@ -638,7 +640,7 @@ fn main() {
 
         for particle in finished_particles {
             //
-            if !particle.incident {
+            if !particle.incident & options.track_displacements {
                     writeln!(
                         displacements_file_stream, "{},{},{},{},{},{}",
                         particle.m/mass_unit, particle.Z, particle.energy_origin/energy_unit,
@@ -690,16 +692,16 @@ fn main() {
                         pos.x/length_unit, pos.y/length_unit, pos.z/length_unit,
                     ).expect(format!("Output error: could not write to {}trajectories.output.", options.name).as_str());
                 }
+            }
 
-                if particle.incident {
-                    for energy_loss in particle.energies {
-                        writeln!(
-                            energy_loss_file_stream, "{},{},{},{},{},{},{}",
-                            particle.m/mass_unit, particle.Z,
-                            energy_loss.En/energy_unit, energy_loss.Ee/energy_unit,
-                            energy_loss.x/length_unit, energy_loss.y/length_unit, energy_loss.z/length_unit,
-                        ).expect(format!("Output error: could not write to {}energy_loss.output.", options.name).as_str());
-                    }
+            if particle.incident & options.track_energy_losses {
+                for energy_loss in particle.energies {
+                    writeln!(
+                        energy_loss_file_stream, "{},{},{},{},{},{},{}",
+                        particle.m/mass_unit, particle.Z,
+                        energy_loss.En/energy_unit, energy_loss.Ee/energy_unit,
+                        energy_loss.x/length_unit, energy_loss.y/length_unit, energy_loss.z/length_unit,
+                    ).expect(format!("Output error: could not write to {}energy_loss.output.", options.name).as_str());
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,26 @@ impl fmt::Display for ElectronicStoppingMode {
     }
 }
 
+#[derive(Deserialize, PartialEq, Clone, Copy)]
+pub enum SurfaceBindingModel {
+    INDIVIDUAL,
+    TARGET,
+    AVERAGE,
+}
+
+impl fmt::Display for SurfaceBindingModel {
+    fn fmt (&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SurfaceBindingModel::INDIVIDUAL => write!(f,
+                "Individual surface binding energies."),
+            SurfaceBindingModel::TARGET => write!(f,
+                "Concentration-dependent linear combinaion of target binding energies."),
+            SurfaceBindingModel::AVERAGE => write!(f,
+                "Average between particle and concentration-dependent linear combination of target binding energies."),
+        }
+    }
+}
+
 
 #[derive(Deserialize, PartialEq, Clone, Copy)]
 pub enum MeanFreePathModel {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -29,7 +29,8 @@ fn test_surface_binding_energy_barrier() {
         m: vec![63.54, 1.0008],
         interaction_index: vec![0, 0],
         electronic_stopping_correction_factor: 0.0,
-        energy_barrier_thickness: 10.
+        energy_barrier_thickness: 10.,
+        surface_binding_model: SurfaceBindingModel::TARGET
     };
 
     let thickness: f64 = 1000.;
@@ -58,7 +59,7 @@ fn test_surface_binding_energy_barrier() {
     assert!(!inside_old);
 
     //Test concentration-dependent surface binding energy
-    let surface_binding_energy = material_1.actual_surface_binding_energy(particle_1.pos.x, particle_1.pos.y);
+    let surface_binding_energy = material_1.actual_surface_binding_energy(&particle_1, particle_1.pos.x, particle_1.pos.y);
     assert!(approx_eq!(f64, surface_binding_energy/EV, (2. + 4.)/2., epsilon=1E-12));
     //println!("sbv: {}", surface_binding_energy/EV);
 
@@ -212,7 +213,8 @@ fn test_momentum_conservation() {
             m: vec![m2],
             interaction_index: vec![0],
             electronic_stopping_correction_factor: 0.0,
-            energy_barrier_thickness: 0.
+            energy_barrier_thickness: 0.,
+            surface_binding_model: SurfaceBindingModel::TARGET
         };
 
         let thickness: f64 = 1000.;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -255,6 +255,8 @@ fn test_momentum_conservation() {
                             num_chunks: 1,
                             use_hdf5: false,
                             root_finder: vec![vec![root_finder]],
+                            track_displacements: false,
+                            track_energy_losses: false,
                         };
 
                         let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material_1, &options);
@@ -413,6 +415,8 @@ fn test_quadrature() {
         num_chunks: 1,
         use_hdf5: false,
         root_finder: vec![vec![Rootfinder::NEWTON{max_iterations: 100, tolerance: 1E-14}]],
+        track_displacements: false,
+        track_energy_losses: false,
     };
 
     let x0_newton = bca::newton_rootfinder(Za, Zb, Ma, Mb, E0, p, InteractionPotential::KR_C, 100, 1E-12).unwrap();


### PR DESCRIPTION
… with TARGET. INDIVIDUAL uses the Es given in particle_parameters as the surface binding energy for each particle with no modification. AVERAGE uses 0 if the particle or target has a surface binding energy of zero, otherwise Es = (particle.Es + target.Es)/2, where target.Es is the linear combination sum(concentration[i]*Es[i]) of the nearest triangle. TARGET will use 0 if particle.Es 0, otherwise it will use the linear combination sum(concentration[i]*Es[i]).