### PR TITLE
Densities and units

### DIFF
--- a/scripts/rustbca.py
+++ b/scripts/rustbca.py
@@ -14,6 +14,8 @@ from enum import Enum
 from collections import namedtuple
 rcParams.update({'figure.autolayout': True})
 
+from generate_ftridyn_input import *
+
 Q = 1.602E-19
 PI = 3.14159
 AMU = 1.66E-27
@@ -207,7 +209,7 @@ tungsten = {
     'Z': 74,
     'm': 183.84,
     'n': 6.306E28,
-    'Es': 11.75,
+    'Es': 8.79,
     'Eb': 0.,
     'Ec': 6.,
     'Q': 0.72,
@@ -476,7 +478,8 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
     track_displacements=True, track_energy_losses=True,
     electronic_stopping_mode=LOW_ENERGY_NONLOCAL,
     weak_collision_order=3, ck=1., mean_free_path_model=LIQUID,
-    interaction_potential=KR_C):
+    interaction_potential=KR_C, high_energy=False, energy_barrier_thickness=(6.306E28)**(-1/3.),
+    initial_particle_position = -1*ANGSTROM, integral="MENDENHALL_WELLER"):
 
     options = {
         'name': name,
@@ -484,16 +487,16 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
         'track_recoils': track_recoils,
         'track_recoil_trajectories': track_recoil_trajectories,
         'stream_size': 8000,
-        'weak_collision_order': 0,
+        'weak_collision_order': 3,
         'suppress_deep_recoils': False,
-        'high_energy_free_flight_paths': True,
-        'num_threads': 8,
+        'high_energy_free_flight_paths': high_energy,
+        'num_threads': 4,
         'num_chunks': 10,
         'use_hdf5': False,
-        'electronic_stopping_mode': "INTERPOLATED",
+        'electronic_stopping_mode': electronic_stopping_mode,
         'mean_free_path_model': LIQUID,
         'interaction_potential': [[interaction_potential]],
-        'scattering_integral': [["MENDENHALL_WELLER"]],
+        'scattering_integral': [[integral]],
         'track_displacements': track_displacements,
         'track_energy_losses': track_energy_losses,
     }
@@ -506,12 +509,10 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
         'Eb': Eb,
         'Es': Esb,
         'Ec': Ecb,
-        'n': n,
         'Z': Zb,
         'm': Mb,
         'interaction_index': np.zeros(len(n), dtype=int),
         'electronic_stopping_correction_factor': ck,
-        'energy_barrier_thickness': sum(n)**(-1./3.)/np.sqrt(2.*np.pi)/MICRON,
         'surface_binding_model': "AVERAGE"
     }
 
@@ -524,14 +525,15 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
     mesh_2d_input = {
         'length_unit': 'MICRON',
         'coordinate_sets': [[0., depth, 0., thickness/2., -thickness/2., -thickness/2.], [0., depth, depth, thickness/2., thickness/2., -thickness/2.]],
-        'densities': [n, n],
+        'densities': [np.array(n)*(MICRON)**3, np.array(n)*(MICRON)**3],
         'boundary_points': [[0., thickness/2.], [depth, thickness/2.], [depth, -thickness/2.], [0., -thickness/2.]],
-        'simulation_boundary_points':  list(simulation_surface.exterior.coords)
+        'simulation_boundary_points':  list(simulation_surface.exterior.coords),
+        'energy_barrier_thickness': energy_barrier_thickness
     }
 
     cosx = np.cos(theta*np.pi/180.)
     sinx = np.sin(theta*np.pi/180.)
-    positions = [(-dx*np.sin(theta*np.pi/180.), 0., 0.) for _ in range(N)]
+    positions = [(initial_particle_position, 0., 0.) for _ in range(N)]
 
     particle_parameters = {
         'length_unit': 'MICRON',
@@ -541,101 +543,6 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
         'm': [Ma for _ in range(N)],
         'Z': [Za for _ in range(N)],
         'E': [E0 for _ in range(N)],
-        'Ec': [Eca for _ in range(N)],
-        'Es': [Esa for _ in range(N)],
-        'interaction_index': np.zeros(N, dtype=int),
-        'pos': positions,
-        'dir': [(cosx, sinx, 0.) for _ in range(N)],
-        'particle_input_filename': ''
-    }
-
-    input_file = {
-        'material_parameters': material_parameters,
-        'particle_parameters': particle_parameters,
-        'mesh_2d_input': mesh_2d_input,
-        'options': options,
-    }
-
-    with open(f'{name}.toml', 'w') as file:
-        toml.dump(input_file, file, encoder=toml.TomlNumpyEncoder())
-
-    with open(f'{name}.toml', 'a') as file:
-        file.write(r'root_finder = [[{"NEWTON"={max_iterations = 100, tolerance=1E-3}}]]')
-
-
-def generate_rustbca_input_hdf5(
-    Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, kTeV, N, N_, theta,
-    thickness, depth, track_trajectories=True, track_recoils=True,
-    track_recoil_trajectories=True, name='test_',
-    track_displacements=True, track_energy_losses=True,
-    electronic_stopping_mode=LOW_ENERGY_NONLOCAL,
-    weak_collision_order=3, ck=1., mean_free_path_model=LIQUID,
-    interaction_potential=KR_C):
-
-    options = {
-        'name': name,
-        'track_trajectories': track_trajectories,
-        'track_recoils': track_recoils,
-        'track_recoil_trajectories': track_recoil_trajectories,
-        'stream_size': 8000,
-        'weak_collision_order': 0,
-        'suppress_deep_recoils': False,
-        'high_energy_free_flight_paths': True,
-        'num_threads': 8,
-        'num_chunks': 10,
-        'use_hdf5': False,
-        'electronic_stopping_mode': "INTERPOLATED",
-        'mean_free_path_model': LIQUID,
-        'interaction_potential': [[interaction_potential]],
-        'scattering_integral': [["MENDENHALL_WELLER"]],
-        'track_displacements': track_displacements,
-        'track_energy_losses': track_energy_losses,
-    }
-
-    dx = 20.*ANGSTROM/MICRON
-
-    material_parameters = {
-        'energy_unit': 'EV',
-        'mass_unit': 'AMU',
-        'Eb': Eb,
-        'Es': Esb,
-        'Ec': Ecb,
-        'n': n,
-        'Z': Zb,
-        'm': Mb,
-        'interaction_index': np.zeros(len(n), dtype=int),
-        'electronic_stopping_correction_factor': ck,
-        'energy_barrier_thickness': sum(n)**(-1./3.)/np.sqrt(2.*np.pi)/MICRON,
-        'surface_binding_model': "AVERAGE"
-    }
-
-    dx = 5.*ANGSTROM/MICRON
-
-    minx, miny, maxx, maxy = 0.0, -thickness/2., depth, thickness/2.
-    surface = box(minx, miny, maxx, maxy)
-
-    simulation_surface = surface.buffer(10.*dx, cap_style=2, join_style=2)
-    mesh_2d_input = {
-        'length_unit': 'MICRON',
-        'coordinate_sets': [[0., depth, 0., thickness/2., -thickness/2., -thickness/2.], [0., depth, depth, thickness/2., thickness/2., -thickness/2.]],
-        'densities': [n, n],
-        'boundary_points': [[0., thickness/2.], [depth, thickness/2.], [depth, -thickness/2.], [0., -thickness/2.]],
-        'simulation_boundary_points':  list(simulation_surface.exterior.coords)
-    }
-
-    cosx = np.cos(theta*np.pi/180.)
-    sinx = np.sin(theta*np.pi/180.)
-    positions = [(-dx*np.sin(theta*np.pi/180.), 0., 0.) for _ in range(N)]
-
-    stdev = np.sqrt(kTeV)
-    particle_parameters = {
-        'length_unit': 'MICRON',
-        'energy_unit': 'EV',
-        'mass_unit': 'AMU',
-        'N': [N_ for _ in range(N)],
-        'm': [Ma for _ in range(N)],
-        'Z': [Za for _ in range(N)],
-        'E': np.random.normal(0.0, stdev, N)**2*(Ma)/2.,
         'Ec': [Eca for _ in range(N)],
         'Es': [Esa for _ in range(N)],
         'interaction_index': np.zeros(N, dtype=int),
@@ -1038,6 +945,8 @@ def all_depth_distributions(name, displacement_energy, N, num_bins=100):
 
 def main():
 
+
+
     Zb = [74]
     Mb = [183.84]
     n = [6.306E28]
@@ -1045,43 +954,93 @@ def main():
     Ecb = [11.75] #Cutoff energy
     Eb = [3.0] #Bulk binding energy
 
-    Za = 1
-    Ma = 1.008
-    Esa = 3.0
-    Eca = 0.1
-    E0 = 20E6
+    Za = 2
+    Ma = 4
+    Esa = 0.0
+    Eca = 1.0
     N = 1
-    N_ = 10000
-    theta = 0.01
-    thickness = 100000
-    depth = 10000
+    N_ = 100000
 
-    name = 'H_on_W_20MeV'
+    thickness = 100000
+    depth = 1000000
+
+    name = 'He_on_W_'
 
     track_trajectories = False
-    plot_trajectories = True
-    track_energy_losses = True
-    track_displacements = True
+    plot_trajectories = False
+    plot_distributions = False
+    track_energy_losses = False
+    track_displacements = False
+    plot_depth_distributions = False
     run_sim = True
 
-    generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
-        theta, thickness, depth, name=name, track_trajectories=track_trajectories,
-        track_recoil_trajectories=track_trajectories, track_energy_losses=track_energy_losses,
-        track_displacements=track_displacements, track_recoils=True)
+    integrals = ["MENDENHALL_WELLER", "MAGIC", "GAUSS_LEGENDRE"]
+    energies = np.logspace(np.log(100)/np.log(10), np.log(2000)/np.log(10), 100)
+    angle = 0.0001
+    emode = LOW_ENERGY_NONLOCAL
 
-    if run_sim: os.system(f'cargo run --release {name}.toml')
+    ftridyn = tridyn_interface('He', 'W')
+    run_ftridyn = True
 
-    if track_energy_losses: plot_energy_loss(name, N*N_, num_bins=200)
+    for integral_index, integral in enumerate(integrals):
+        s = []
+        for index, energy in enumerate(energies):
 
-    all_depth_distributions(name, 38., N_*N, num_bins=200)
+            generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, energy, N, N_,
+                angle, thickness, depth, name=name+str(index)+'_'+str(integral_index), track_trajectories=track_trajectories,
+                track_recoil_trajectories=track_trajectories, track_energy_losses=track_energy_losses,
+                track_displacements=track_displacements, track_recoils=True,
+                electronic_stopping_mode=emode, integral=integral)
 
-    if track_trajectories and plot_trajectories:
-        do_trajectory_plot(name, thickness=thickness, depth=depth, num_trajectories=100, plot_final_positions=False)
+            if run_sim: os.system(f'rustBCA.exe {name+str(index)+"_"+str(integral_index)}.toml')
+            sputtered = np.atleast_2d(np.genfromtxt(name+str(index)+'_'+str(integral_index)+'sputtered.output', delimiter=','))
 
-    plot_distributions_rustbca(name, hydrogen, boron, incident_angle=theta, incident_energy=E0)
+            if np.size(sputtered) > 0:
+                s.append(np.shape(sputtered)[0]/(N_*N))
+            else:
+                s.append(0.0)
 
+            if track_energy_losses: plot_energy_loss(name+str(index)+'_'+str(integral_index), N*N_, num_bins=200)
 
-    if track_displacements: plot_displacements(name, 20., N*N_, num_bins=200)
+            if plot_depth_distributions: all_depth_distributions(name+'_'+str(index)+str(integral_index), 38., N_*N, num_bins=200)
+
+            if track_trajectories and plot_trajectories:
+                do_trajectory_plot(name, thickness=thickness, depth=depth, num_trajectories=100, plot_final_positions=False)
+
+            if plot_distributions: plot_distributions_rustbca(name+str(index)+'_'+str(integral_index), hydrogen, boron, incident_angle=angle, incident_energy=energy)
+
+            if track_displacements: plot_displacements(name+str(index)+'_'+str(integral_index), 20., N*N_, num_bins=200)
+
+        plt.plot(energies, s)
+
+    sf = []
+    for index, energy in enumerate(energies):
+        if run_ftridyn:
+            _, _, _ = ftridyn.run_tridyn_simulations_from_iead([energy], [angle], [[N_]], number_histories=1, depth=depth)
+            os.system(f'cp HeW_SPLST.DAT HeW_sputtered_{str(index)}.DAT')
+        sarray = np.atleast_2d(np.genfromtxt(f'HeW_sputtered_{str(index)}.DAT'))
+
+        if np.size(sarray) > 0:
+            num_sputtered = np.shape(sarray)[0]
+        else:
+            num_sputtered = 0
+
+        ftridyn_yield = num_sputtered/N_
+        sf.append(ftridyn_yield)
+
+    plt.plot(energies, sf)
+
+    sy = []
+    sb = []
+    for energy in energies:
+        sy.append(yamamura(helium, tungsten, energy))
+        sb.append(bohdansky_light_ion(helium, tungsten, energy))
+
+    plt.plot(energies, sy)
+    plt.plot(energies, sb)
+    plt.legend(integrals+['F-TRIDYN', 'Yamamura', 'Bohdansky'])
+    plt.show()
+
 
 if __name__ == '__main__':
     main()

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -397,10 +397,10 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
 
     //If particle energy  drops below zero before electronic stopping calcualtion, it produces NaNs
     particle_1.E -= recoil_energy;
+    assert!(!particle_1.E.is_nan(), "Numerical error: particle energy is NaN following collision.");
     if particle_1.E < 0. {
         particle_1.E = 0.;
     }
-
 
 
     let x = particle_1.pos.x;
@@ -426,8 +426,10 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
             },
         };
 
+
         particle_1.E += -delta_energy;
         //Make sure particle energy doesn't become negative again
+        assert!(!particle_1.E.is_nan(), "Numerical error: particle energy is NaN following electronic stopping.");
         if particle_1.E < 0. {
             particle_1.E = 0.;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,11 +339,10 @@ fn main() {
     let particle_parameters = input.particle_parameters;
 
     //Check that all material arrays are of equal length.
-    assert!(material.n.len() == material.m.len(), "Input error: material input arrays of unequal length.");
-    assert!(material.n.len() == material.Z.len(), "Input error: material input arrays of unequal length.");
-    assert!(material.n.len() == material.Eb.len(), "Input error: material input arrays of unequal length.");
-    assert!(material.n.len() == material.Es.len(), "Input error: material input arrays of unequal length.");
-    assert!(material.n.len() == material.interaction_index.len(), "Input error: material input arrays of unequal length.");
+    assert!(material.m.len() == material.Z.len(), "Input error: material input arrays of unequal length.");
+    assert!(material.m.len() == material.Eb.len(), "Input error: material input arrays of unequal length.");
+    assert!(material.m.len() == material.Es.len(), "Input error: material input arrays of unequal length.");
+    assert!(material.m.len() == material.interaction_index.len(), "Input error: material input arrays of unequal length.");
 
     //Check that incompatible options are not on simultaneously
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -11,7 +11,6 @@ pub struct MaterialParameters {
     pub Eb: Vec<f64>,
     pub Es: Vec<f64>,
     pub Ec: Vec<f64>,
-    pub n: Vec<f64>,
     pub Z: Vec<f64>,
     pub m: Vec<f64>,
     pub interaction_index: Vec<usize>,
@@ -21,7 +20,6 @@ pub struct MaterialParameters {
 }
 
 pub struct Material {
-    pub n: Vec<f64>,
     pub m: Vec<f64>,
     pub Z: Vec<f64>,
     pub Eb: Vec<f64>,
@@ -65,7 +63,6 @@ impl Material {
         };
 
         Material {
-            n: material_parameters.n,
             m: material_parameters.m.iter().map(|&i| i*mass_unit).collect(),
             Z: material_parameters.Z,
             Eb: material_parameters.Eb.iter().map(|&i| i*energy_unit).collect(),
@@ -236,11 +233,15 @@ impl Material {
         let Ma = particle_1.m;
         let Za = particle_1.Z;
 
-        let mut stopping_powers = Vec::with_capacity(self.n.len());
+        let mut stopping_powers = Vec::with_capacity(self.Z.len());
 
         //Bragg's rule: total stopping power is sum of stopping powers of individual atoms
         //Therefore, compute each stopping power separately, and add them up
-        for (n, Zb) in self.n.iter().zip(&self.Z) {
+
+        let x = particle_1.pos.x;
+        let y = particle_1.pos.y;
+
+        for (n, Zb) in self.number_densities(x, y).iter().zip(&self.Z) {
             //let n = self.number_density(particle_1.pos.x, particle_1.pos.y);
             //let Zb = self.Z_eff(particle_1.pos.x, particle_1.pos.y);
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -15,7 +15,6 @@ pub struct MaterialParameters {
     pub m: Vec<f64>,
     pub interaction_index: Vec<usize>,
     pub electronic_stopping_correction_factor: f64,
-    pub energy_barrier_thickness: f64,
     pub surface_binding_model: SurfaceBindingModel
 }
 
@@ -28,7 +27,6 @@ pub struct Material {
     pub interaction_index: Vec<usize>,
     pub electronic_stopping_correction_factor: f64,
     pub mesh_2d: mesh::Mesh2D,
-    pub energy_barrier_thickness: f64,
     pub surface_binding_model: SurfaceBindingModel
 
 }
@@ -71,7 +69,6 @@ impl Material {
             interaction_index: material_parameters.interaction_index,
             electronic_stopping_correction_factor: material_parameters.electronic_stopping_correction_factor,
             mesh_2d: mesh::Mesh2D::new(mesh_2d_input),
-            energy_barrier_thickness: material_parameters.energy_barrier_thickness*length_unit,
             surface_binding_model: material_parameters.surface_binding_model,
         }
     }
@@ -133,7 +130,7 @@ impl Material {
         } else {
             let nearest_cell = self.mesh_2d.nearest_cell_to(x, y);
             let distance = nearest_cell.distance_to(x, y);
-            distance < self.energy_barrier_thickness
+            distance < self.mesh_2d.energy_barrier_thickness
         }
         //let p = point!(x: x, y: y);
         //return self.energy_surface.contains(&p);

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -23,9 +23,7 @@ impl Mesh2D {
         let coordinate_sets = mesh_2d_input.coordinate_sets;
         let boundary_points = mesh_2d_input.boundary_points;
         let simulation_boundary_points = mesh_2d_input.simulation_boundary_points;
-        let densities = mesh_2d_input.densities;
 
-        assert_eq!(coordinate_sets.len(), densities.len(), "Input error: coordinates and data of unequal length.");
         let n = coordinate_sets.len();
 
         let mut cells: Vec<Cell2D> =  Vec::with_capacity(n);
@@ -40,6 +38,11 @@ impl Mesh2D {
             _ => panic!("Input error: incorrect unit {} in input file. Choose one of: MICRON, CM, ANGSTROM, NM, M",
                 mesh_2d_input.length_unit.as_str())
         };
+
+        let densities: Vec<Vec<f64>> = mesh_2d_input.densities
+            .iter()
+            .map( |row| row.iter().map(|element| element/(length_unit).powf(3.)).collect() ).collect();
+        assert_eq!(coordinate_sets.len(), densities.len(), "Input error: coordinates and data of unequal length.");
 
         for (coordinate_set, densities) in coordinate_sets.iter().zip(densities) {
             let coordinate_set_converted = (

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -10,12 +10,14 @@ pub struct Mesh2DInput {
     pub boundary_points: Vec<(f64, f64)>,
     pub simulation_boundary_points: Vec<(f64, f64)>,
     pub densities: Vec<Vec<f64>>,
+    pub energy_barrier_thickness: f64,
 }
 
 pub struct Mesh2D {
     mesh: Vec<Cell2D>,
     pub boundary: Polygon<f64>,
-    pub simulation_boundary: Polygon<f64>
+    pub simulation_boundary: Polygon<f64>,
+    pub energy_barrier_thickness: f64
 }
 impl Mesh2D {
     pub fn new(mesh_2d_input: Mesh2DInput) -> Mesh2D {
@@ -72,10 +74,13 @@ impl Mesh2D {
         }
         let simulation_boundary: Polygon<f64> = Polygon::new(LineString::from(simulation_boundary_points_converted), vec![]);
 
+        let energy_barrier_thickness = mesh_2d_input.energy_barrier_thickness*length_unit;
+
         Mesh2D {
             mesh: cells,
             boundary: boundary,
-            simulation_boundary: simulation_boundary
+            simulation_boundary: simulation_boundary,
+            energy_barrier_thickness: energy_barrier_thickness,
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,7 +24,6 @@ fn test_surface_binding_energy_barrier() {
         Eb: vec![0.0, 0.0],
         Es: vec![2.0, 4.0],
         Ec: vec![1.0, 1.0],
-        n: vec![6E28, 6E28],
         Z: vec![29., 1.],
         m: vec![63.54, 1.0008],
         interaction_index: vec![0, 0],
@@ -38,7 +37,7 @@ fn test_surface_binding_energy_barrier() {
     let mesh_2d_input = mesh::Mesh2DInput {
         length_unit: "ANGSTROM".to_string(),
         coordinate_sets: vec![(0., depth, 0., thickness/2., thickness/2., -thickness/2.), (depth, depth, 0., thickness/2., -thickness/2., -thickness/2.)],
-        densities: vec![vec![3E28, 3E28], vec![3E28, 3E28]],
+        densities: vec![vec![0.03, 0.03], vec![0.03, 0.03]],
         boundary_points: vec![(0., thickness/2.), (depth, thickness/2.), (depth, -thickness/2.), (0., -thickness/2.), (0., thickness/2.)],
         simulation_boundary_points: vec![(0., 1.1*thickness/2.), (depth, 1.1*thickness/2.), (depth, -1.1*thickness/2.), (0., -1.1*thickness/2.), (0., 1.1*thickness/2.)]
     };
@@ -208,7 +207,6 @@ fn test_momentum_conservation() {
             Eb: vec![0.0],
             Es: vec![Es2],
             Ec: vec![Ec2],
-            n: vec![6.026E28],
             Z: vec![Z2],
             m: vec![m2],
             interaction_index: vec![0],
@@ -222,7 +220,7 @@ fn test_momentum_conservation() {
         let mesh_2d_input = mesh::Mesh2DInput {
             length_unit: "ANGSTROM".to_string(),
             coordinate_sets: vec![(0., depth, 0., thickness/2., thickness/2., -thickness/2.), (depth, depth, 0., thickness/2., -thickness/2., -thickness/2.)],
-            densities: vec![vec![6.026E28], vec![6.026E28]],
+            densities: vec![vec![0.06306], vec![0.06306]],
             boundary_points: vec![(0., thickness/2.), (depth, thickness/2.), (depth, -thickness/2.), (0., -thickness/2.), (0., thickness/2.)],
             simulation_boundary_points: vec![(0., 1.1*thickness/2.), (depth, 1.1*thickness/2.), (depth, -1.1*thickness/2.), (0., -1.1*thickness/2.), (0., 1.1*thickness/2.)]
         };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,7 +28,6 @@ fn test_surface_binding_energy_barrier() {
         m: vec![63.54, 1.0008],
         interaction_index: vec![0, 0],
         electronic_stopping_correction_factor: 0.0,
-        energy_barrier_thickness: 10.,
         surface_binding_model: SurfaceBindingModel::TARGET
     };
 
@@ -39,7 +38,8 @@ fn test_surface_binding_energy_barrier() {
         coordinate_sets: vec![(0., depth, 0., thickness/2., thickness/2., -thickness/2.), (depth, depth, 0., thickness/2., -thickness/2., -thickness/2.)],
         densities: vec![vec![0.03, 0.03], vec![0.03, 0.03]],
         boundary_points: vec![(0., thickness/2.), (depth, thickness/2.), (depth, -thickness/2.), (0., -thickness/2.), (0., thickness/2.)],
-        simulation_boundary_points: vec![(0., 1.1*thickness/2.), (depth, 1.1*thickness/2.), (depth, -1.1*thickness/2.), (0., -1.1*thickness/2.), (0., 1.1*thickness/2.)]
+        simulation_boundary_points: vec![(0., 1.1*thickness/2.), (depth, 1.1*thickness/2.), (depth, -1.1*thickness/2.), (0., -1.1*thickness/2.), (0., 1.1*thickness/2.)],
+        energy_barrier_thickness: 10.,
     };
 
     let material_1 = material::Material::new(material_parameters, mesh_2d_input);
@@ -211,7 +211,6 @@ fn test_momentum_conservation() {
             m: vec![m2],
             interaction_index: vec![0],
             electronic_stopping_correction_factor: 0.0,
-            energy_barrier_thickness: 0.,
             surface_binding_model: SurfaceBindingModel::TARGET
         };
 
@@ -222,7 +221,8 @@ fn test_momentum_conservation() {
             coordinate_sets: vec![(0., depth, 0., thickness/2., thickness/2., -thickness/2.), (depth, depth, 0., thickness/2., -thickness/2., -thickness/2.)],
             densities: vec![vec![0.06306], vec![0.06306]],
             boundary_points: vec![(0., thickness/2.), (depth, thickness/2.), (depth, -thickness/2.), (0., -thickness/2.), (0., thickness/2.)],
-            simulation_boundary_points: vec![(0., 1.1*thickness/2.), (depth, 1.1*thickness/2.), (depth, -1.1*thickness/2.), (0., -1.1*thickness/2.), (0., 1.1*thickness/2.)]
+            simulation_boundary_points: vec![(0., 1.1*thickness/2.), (depth, 1.1*thickness/2.), (depth, -1.1*thickness/2.), (0., -1.1*thickness/2.), (0., 1.1*thickness/2.)],
+            energy_barrier_thickness: 0.,
         };
 
         let material_1 = material::Material::new(material_parameters, mesh_2d_input);


### PR DESCRIPTION
This version makes some common sense changes to the input file, and includes a minor fix to electronic stopping of compounds.

1. `energy_barrier_thickness` is now a mesh input parameter
2. `material_params `no longer has redundant `n` (number densities) option
3.  electronic stopping for compounds switched from depending on `material_params` `n` to the actual mesh densities]
4. densities in the mesh input file use the inverse cubic unit chosen - so, the default unit is "MICRON", so the default density input should be in [atoms/micron^3]
5. `energy_barrier_thickness `now uses the correct unit from the input file