### PR TITLE
[constants] update the values of the physical & mathematical constants

### DIFF
--- a/scripts/formulas.py
+++ b/scripts/formulas.py
@@ -1,21 +1,22 @@
+from scipy import constants
 from scipy.interpolate import interp1d
 import numpy as np
 
 #Constants
-Q = 1.602E-19
-PI = 3.14159
-AMU = 1.66E-27
-ANGSTROM = 1E-10
-MICRON = 1E-6
-NM = 1E-9
-CM = 1E-2
-EPS0 = 8.85E-12
-A0 = 0.52918E-10
-K = 1.11265E-10
-ME = 9.11E-31
-SQRTPI = 1.77245385
-SQRT2PI = 2.506628274631
-C = 299792000.
+Q = constants.physical_constants["elementary charge"][0]
+PI = constants.pi
+AMU = constants.physical_constants["unified atomic mass unit"][0]
+ANGSTROM = constants.angstrom
+MICRON = constants.micro
+NM = constants.nano
+CM = constants.centi
+EPS0 = constants.epsilon_0
+A0 = constants.physical_constants["Bohr radius"][0]
+K = constants.physical_constants["atomic unit of permittivity"][0]
+ME = constants.physical_constants["electron mass"][0]
+SQRTPI = np.sqrt(PI)
+SQRT2PI = np.sqrt(2 * PI)
+C = constants.physical_constants["speed of light in vacuum"][0]
 
 def thomas_reflection(ion, target, energy_eV):
     '''

--- a/scripts/rustbca.py
+++ b/scripts/rustbca.py
@@ -4,7 +4,7 @@ import time
 import toml
 import numpy as np
 from shapely.geometry import Point, Polygon, box
-
+from scipy import constants
 import matplotlib.pyplot as plt
 from matplotlib import rcParams, cm
 import matplotlib as mpl
@@ -18,20 +18,20 @@ from generate_ftridyn_input import *
 rcParams.update({'figure.autolayout': True})
 
 #Constants
-Q = 1.602E-19
-PI = 3.14159
-AMU = 1.66E-27
-ANGSTROM = 1E-10
-MICRON = 1E-6
-NM = 1E-9
-CM = 1E-2
-EPS0 = 8.85E-12
-A0 = 0.52918E-10
-K = 1.11265E-10
-ME = 9.11E-31
-SQRTPI = 1.77245385
-SQRT2PI = 2.506628274631
-C = 299792000.
+Q = constants.physical_constants["elementary charge"][0]
+PI = constants.pi
+AMU = constants.physical_constants["unified atomic mass unit"][0]
+ANGSTROM = constants.angstrom
+MICRON = constants.micro
+NM = constants.nano
+CM = constants.centi
+EPS0 = constants.epsilon_0
+A0 = constants.physical_constants["Bohr radius"][0]
+K = constants.physical_constants["atomic unit of permittivity"][0]
+ME = constants.physical_constants["electron mass"][0]
+SQRTPI = np.sqrt(PI)
+SQRT2PI = np.sqrt(2 * PI)
+C = constants.physical_constants["speed of light in vacuum"][0]
 
 INTERPOLATED = "INTERPOLATED"
 LOW_ENERGY_NONLOCAL = "LOW_ENERGY_NONLOCAL"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,11 @@ use rayon::*;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::io::BufWriter;
+
+//Math
+use std::f64::consts::FRAC_2_SQRT_PI;
 use std::f64::consts::PI;
+use std::f64::consts::SQRT_2;
 
 //Load internal modules
 pub mod material;
@@ -48,11 +52,11 @@ pub mod mesh;
 
 //Physical constants
 ///Fundamental charge in Coulombs.
-const Q: f64 = 1.60217646E-19;
+const Q: f64 = 1.602176634E-19;
 /// One electron-volt in Joules.
 const EV: f64 = Q;
 /// One atomic mass unit in kilograms.
-const AMU: f64 = 1.660539E-27;
+const AMU: f64 = 1.66053906660E-27;
 /// One Angstrom in meters.
 const ANGSTROM: f64 = 1E-10;
 /// One micron in meters.
@@ -62,17 +66,17 @@ const NM: f64 = 1E-9;
 /// One centimeter in meters.
 const CM: f64 = 1E-2;
 /// Vacuum permitivity in Farads/meter.
-const EPS0: f64 = 8.85418781E-12;
+const EPS0: f64 = 8.8541878128E-12;
 /// Bohr radius in meters.
-const A0: f64 = 5.29177211E-11;
+const A0: f64 = 5.29177210903E-11;
 /// Electron mass in kilograms.
-const ME: f64 =  9.109383632E-31;
+const ME: f64 = 9.1093837015E-31;
 /// sqrt(pi).
-const SQRTPI: f64 = 1.772453850906;
+const SQRTPI: f64 = 2. / FRAC_2_SQRT_PI;
 /// sqrt(2 * pi).
-const SQRT2PI: f64 = 2.506628274631;
+const SQRT2PI: f64 = 2. * SQRT_2 / FRAC_2_SQRT_PI;
 /// Speed of light in meters/second.
-const C: f64 = 299792000.;
+const C: f64 = 299792458.;
 /// Bethe-Bloch electronic stopping prefactor, in SI units.
 const BETHE_BLOCH_PREFACTOR: f64 = 4.*PI*(Q*Q/(4.*PI*EPS0))*(Q*Q/(4.*PI*EPS0))/ME/C/C;
 /// Lindhard-Scharff electronic stopping prefactor, in SI units.


### PR DESCRIPTION
- Update the physical constants to their 2018 CODATA values (see https://physics.nist.gov/cuu/Constants/index.html).
- Retrieve/calculate the mathematical constants using library values, giving them full double precision.