### PR TITLE
Removed bad variable names in closures.

### DIFF
--- a/src/bca.rs
+++ b/src/bca.rs
@@ -234,7 +234,7 @@ pub fn determine_mfp_phi_impact_parameter(particle_1: &mut particle::Particle, m
         let mut ffp = 1./(material.total_number_density(x, y)*pmax*pmax*PI);
         let stopping_powers = material.electronic_stopping_cross_sections(particle_1, ElectronicStoppingMode::INTERPOLATED);
 
-        let delta_energy_electronic = stopping_powers.iter().zip(material.number_densities(x, y)).map(|(&i1, i2)| i1*i2).sum::<f64>()*ffp*ck;
+        let delta_energy_electronic = stopping_powers.iter().zip(material.number_densities(x, y)).map(|(&se, number_density)| se*number_density).sum::<f64>()*ffp*ck;
 
         //If losing too much energy, scale free-flight-path down
         //5 percent limit set in original TRIM paper, Biersack and Haggmark 1980
@@ -425,13 +425,13 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
         let n = material.number_densities(x, y);
 
         let delta_energy = match options.electronic_stopping_mode {
-            ElectronicStoppingMode::INTERPOLATED => electronic_stopping_powers.iter().zip(n).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled,
-            ElectronicStoppingMode::LOW_ENERGY_NONLOCAL => electronic_stopping_powers.iter().zip(n).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled,
+            ElectronicStoppingMode::INTERPOLATED => electronic_stopping_powers.iter().zip(n).map(|(se, number_density)| se*number_density).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled,
+            ElectronicStoppingMode::LOW_ENERGY_NONLOCAL => electronic_stopping_powers.iter().zip(n).map(|(se, number_density)| se*number_density).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled,
             ElectronicStoppingMode::LOW_ENERGY_LOCAL => oen_robinson_loss(particle_1.Z, strong_collision_Z, electronic_stopping_powers[strong_collision_index], x0, interaction_potential),
             ElectronicStoppingMode::LOW_ENERGY_EQUIPARTITION => {
 
                 let delta_energy_local = oen_robinson_loss(particle_1.Z, strong_collision_Z, electronic_stopping_powers[strong_collision_index], x0, interaction_potential);
-                let delta_energy_nonlocal = electronic_stopping_powers.iter().zip(n).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled;
+                let delta_energy_nonlocal = electronic_stopping_powers.iter().zip(n).map(|(se, number_density)| se*number_density).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled;
 
                 (0.5*delta_energy_local + 0.5*delta_energy_nonlocal)
             },

--- a/src/material.rs
+++ b/src/material.rs
@@ -173,14 +173,14 @@ impl Material {
     /// Finds the average, concentration-weighted atomic number, Z_effective, of the triangle that contains or is nearest to (x, y).
     pub fn average_Z(&self, x: f64, y: f64) -> f64 {
         let concentrations = self.mesh_2d.get_concentrations(x, y);
-        return self.Z.iter().zip(concentrations).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum();
+        return self.Z.iter().zip(concentrations).map(|(charge, concentration)| charge*concentration).collect::<Vec<f64>>().iter().sum();
         //return self.Z.iter().sum::<f64>()/self.Z.len() as f64;
     }
 
     /// Finds the average, concentration-weighted atomic mass, m_effective, of the triangle that contains or is nearest to (x, y).
     pub fn average_mass(&self, x: f64, y: f64) -> f64 {
         let concentrations = self.mesh_2d.get_concentrations(x, y);
-        return self.m.iter().zip(concentrations).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum();
+        return self.m.iter().zip(concentrations).map(|(mass, concentration)| mass*concentration).collect::<Vec<f64>>().iter().sum();
         //return self.m.iter().sum::<f64>()/self.m.len() as f64;
     }
 
@@ -188,7 +188,7 @@ impl Material {
     pub fn average_bulk_binding_energy(&self, x: f64, y: f64) -> f64 {
         //returns average bulk binding energy
         let concentrations = self.mesh_2d.get_concentrations(x, y);
-        return self.Eb.iter().zip(concentrations).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum();
+        return self.Eb.iter().zip(concentrations).map(|(bulk_binding_energy, concentration)| bulk_binding_energy*concentration).collect::<Vec<f64>>().iter().sum();
         //return self.Eb.iter().sum::<f64>()/self.Eb.len() as f64;
     }
 
@@ -207,7 +207,7 @@ impl Material {
                 if particle.Es == 0. {
                     0.
                 } else {
-                    self.Es.iter().zip(concentrations).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum()
+                    self.Es.iter().zip(concentrations).map(|(surface_binding_energy, concentration)| surface_binding_energy*concentration).collect::<Vec<f64>>().iter().sum()
                 }
             },
 
@@ -215,7 +215,7 @@ impl Material {
                 if (particle.Es == 0.) | (self.Es.iter().sum::<f64>() == 0.) {
                     0.
                 } else {
-                    0.5*(particle.Es + self.Es.iter().zip(concentrations).map(|(i1, i2)| i1*i2).collect::<Vec<f64>>().iter().sum::<f64>())
+                    0.5*(particle.Es + self.Es.iter().zip(concentrations).map(|(surface_binding_energy, concentration)| surface_binding_energy*concentration).collect::<Vec<f64>>().iter().sum::<f64>())
                 }
             },
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -70,7 +70,7 @@ impl Mesh2D {
             );
 
             let total_density: f64 = densities.iter().sum();
-            let concentrations: Vec<f64> = densities.iter().map(|&i| i/total_density).collect::<Vec<f64>>();
+            let concentrations: Vec<f64> = densities.iter().map(|&density| density/total_density).collect::<Vec<f64>>();
 
             cells.push(Cell2D::new(coordinate_set_converted, densities, concentrations, ck));
         }


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #64 

## Description
Uses of variable names such as `i1` have been removed from closures and replaced with meaningful names, such as `concentration`.

## Tests
`cargo test` results in all tests passed. 
