### PR TITLE
Added initial version of summary output file. Fixed parenthesis warning.

### DIFF
--- a/src/bca.rs
+++ b/src/bca.rs
@@ -433,7 +433,7 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
                 let delta_energy_local = oen_robinson_loss(particle_1.Z, strong_collision_Z, electronic_stopping_powers[strong_collision_index], x0, interaction_potential);
                 let delta_energy_nonlocal = electronic_stopping_powers.iter().zip(n).map(|(se, number_density)| se*number_density).collect::<Vec<f64>>().iter().sum::<f64>()*distance_traveled;
 
-                (0.5*delta_energy_local + 0.5*delta_energy_nonlocal)
+                0.5*delta_energy_local + 0.5*delta_energy_nonlocal
             },
         };
 


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Addresses #62 

## Description
A new summary output file for use in code-coupling has been requested; the initial version of this simply includes total incident ion number, total number of sputtered material atoms, and total number of reflected ions (as neutrals) in labeled columns in a CSV file.

Additionally, fixes a warning of extraneous parentheses.

## Tests
cargo test
