### PR TITLE
Added float parser to units; that way, a user can specify a length un…

### DIFF
--- a/examples/layered_geometry.toml
+++ b/examples/layered_geometry.toml
@@ -34,7 +34,7 @@ y_num = 20
 z_num = 20
 
 [particle_parameters]
-length_unit = "MICRON"
+length_unit = "1e-6"
 energy_unit = "EV"
 mass_unit = "AMU"
 N = [ 100000,]
@@ -45,7 +45,7 @@ Ec = [ 1.0,]
 Es = [ 0.0,]
 interaction_index = [0]
 pos = [ [ -1.7453292519934434e-8, 0.0, 0.0,],]
-dir = [ [ 0.5, 0.5, 0.0,],]
+dir = [ [ 0.999, 0.0001, 0.0,],]
 particle_input_filename = ""
 
 [mesh_2d_input]

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -128,6 +128,7 @@ pub fn single_ion_bca(particle: particle::Particle, material: &material::Materia
 
                     particle::rotate_particle(&mut particle_2, -binary_collision_result.psi_recoil,
                         binary_collision_geometry.phi_azimuthal);
+                        
                     particle_2.dir_old.x = particle_2.dir.x;
                     particle_2.dir_old.y = particle_2.dir.y;
                     particle_2.dir_old.z = particle_2.dir.z;
@@ -413,7 +414,6 @@ pub fn update_particle_energy(particle_1: &mut particle::Particle, material: &ma
     if particle_1.E < 0. {
         particle_1.E = 0.;
     }
-
 
     let x = particle_1.pos.x;
     let y = particle_1.pos.y;

--- a/src/input.rs
+++ b/src/input.rs
@@ -72,7 +72,6 @@ pub struct Options {
     pub z_num: usize,
 }
 
-// final three arguments are length, energy, and mass unit for output
 pub fn input() -> (Vec<particle::ParticleInput>, material::Material, Options, OutputUnits){
 
     let args: Vec<String> = env::args().collect();
@@ -189,8 +188,10 @@ pub fn input() -> (Vec<particle::ParticleInput>, material::Material, Options, Ou
         "ANGSTROM" => ANGSTROM,
         "NM" => NM,
         "M" => 1.,
-        _ => panic!("Input error: unknown unit {} in input file. Choose one of: MICRON, CM, ANGSTROM, NM, M",
-            particle_parameters.length_unit.as_str())
+        _ => particle_parameters.length_unit.parse()
+            .expect(format!(
+                    "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &particle_parameters.length_unit.as_str()
+                ).as_str()),
     };
 
     let energy_unit: f64 = match particle_parameters.energy_unit.as_str() {
@@ -198,15 +199,19 @@ pub fn input() -> (Vec<particle::ParticleInput>, material::Material, Options, Ou
         "J"  => 1.,
         "KEV" => EV*1E3,
         "MEV" => EV*1E6,
-        _ => panic!("Input error: unknown unit {} in input file. Choose one of: EV, J, KEV, MEV",
-            particle_parameters.energy_unit.as_str())
+        _ => particle_parameters.energy_unit.parse()
+            .expect(format!(
+                    "Input errror: could nor parse energy unit {}. Use a valid float or one of EV, J, KEV, MEV", &particle_parameters.energy_unit.as_str()
+                ).as_str()),
     };
 
     let mass_unit: f64 = match particle_parameters.mass_unit.as_str() {
         "AMU" => AMU,
         "KG" => 1.0,
-        _ => panic!("Input error: unknown unit {} in input file. Choose one of: AMU, KG",
-            particle_parameters.mass_unit.as_str())
+        _ => particle_parameters.mass_unit.parse()
+            .expect(format!(
+                    "Input errror: could nor parse mass unit {}. Use a valid float or one of AMU, KG", &particle_parameters.mass_unit.as_str()
+                ).as_str()),
     };
 
     //HDF5

--- a/src/material.rs
+++ b/src/material.rs
@@ -34,25 +34,12 @@ impl Material {
     /// Constructs a new material object from a material parameters object and a mesh_2d_input object.
     pub fn new(material_parameters: MaterialParameters, mesh_2d_input: mesh::Mesh2DInput) -> Material {
 
-        //Multiply all coordinates by value of geometry unit.
-        let length_unit: f64 = match mesh_2d_input.length_unit.as_str() {
-            "MICRON" => MICRON,
-            "CM" => CM,
-            "ANGSTROM" => ANGSTROM,
-            "NM" => NM,
-            "M" => 1.,
-            _ => particle_parameters.length_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &material_parameters.length_unit.as_str()
-                    ).as_str()),
-        };
-
         let energy_unit: f64 = match material_parameters.energy_unit.as_str() {
             "EV" => EV,
             "J"  => 1.,
             "KEV" => EV*1E3,
             "MEV" => EV*1E6,
-            _ => particle_parameters.energy_unit.parse()
+            _ => material_parameters.energy_unit.parse()
                 .expect(format!(
                         "Input errror: could nor parse energy unit {}. Use a valid float or one of EV, J, KEV, MEV", &material_parameters.energy_unit.as_str()
                     ).as_str()),
@@ -61,7 +48,7 @@ impl Material {
         let mass_unit: f64 = match material_parameters.mass_unit.as_str() {
             "AMU" => AMU,
             "KG" => 1.,
-            _ => particle_parameters.mass_unit.parse()
+            _ => material_parameters.mass_unit.parse()
                 .expect(format!(
                         "Input errror: could nor parse mass unit {}. Use a valid float or one of AMU, KG", &material_parameters.mass_unit.as_str()
                     ).as_str()),

--- a/src/material.rs
+++ b/src/material.rs
@@ -41,8 +41,10 @@ impl Material {
             "ANGSTROM" => ANGSTROM,
             "NM" => NM,
             "M" => 1.,
-            _ => panic!("Input error: incorrect unit {} in input file. Choose one of: MICRON, CM, ANGSTROM, NM, M",
-                mesh_2d_input.length_unit.as_str())
+            _ => particle_parameters.length_unit.parse()
+                .expect(format!(
+                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &material_parameters.length_unit.as_str()
+                    ).as_str()),
         };
 
         let energy_unit: f64 = match material_parameters.energy_unit.as_str() {
@@ -50,15 +52,19 @@ impl Material {
             "J"  => 1.,
             "KEV" => EV*1E3,
             "MEV" => EV*1E6,
-            _ => panic!("Input error: incorrect unit {} in input file. Choose one of: EV, J, KEV, MEV",
-                material_parameters.energy_unit.as_str())
+            _ => particle_parameters.energy_unit.parse()
+                .expect(format!(
+                        "Input errror: could nor parse energy unit {}. Use a valid float or one of EV, J, KEV, MEV", &material_parameters.energy_unit.as_str()
+                    ).as_str()),
         };
 
         let mass_unit: f64 = match material_parameters.mass_unit.as_str() {
             "AMU" => AMU,
             "KG" => 1.,
-            _ => panic!("Input error: incorrect unit {} in input file. Choose one of: AMU, KG",
-                material_parameters.mass_unit.as_str())
+            _ => particle_parameters.mass_unit.parse()
+                .expect(format!(
+                        "Input errror: could nor parse mass unit {}. Use a valid float or one of AMU, KG", &material_parameters.mass_unit.as_str()
+                    ).as_str()),
         };
 
         Material {

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -42,8 +42,10 @@ impl Mesh2D {
             "ANGSTROM" => ANGSTROM,
             "NM" => NM,
             "M" => 1.,
-            _ => panic!("Input error: incorrect unit {} in input file. Choose one of: MICRON, CM, ANGSTROM, NM, M",
-                mesh_2d_input.length_unit.as_str())
+            _ => mesh_2d_input.length_unit.parse()
+                .expect(format!(
+                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &mesh_2d_input.length_unit.as_str()
+                    ).as_str()),
         };
 
         let densities: Vec<Vec<f64>> = mesh_2d_input.densities


### PR DESCRIPTION
…it of 1e-6 instead of writing MICRON.

Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #24

## Description
Uses the string parsing method to attempt to parse energy, mass, and length units as floats - so a user can write "1e-6" instead of MICRON, or use any arbitrary unit.

## Tests
Updated examples/layered_geometry.toml to use some arbitrary units; tests check out.
