### PR TITLE
Added THRESHOLD{density: f64} mean free path mode. Any cell with tota…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ name="rustBCA"
 
 [dependencies]
 rand = "0.8.3"
-
 toml = "0.5.8"
 anyhow = "1.0.38"
 itertools = "0.10.0"
@@ -40,5 +39,3 @@ cpr_rootfinder_netlib = ["rcpr", "netlib-src"]
 cpr_rootfinder_intel_mkl = ["rcpr", "intel-mkl-src"]
 distributions = ["ndarray"]
 no_list_output = []
-mesh_0D = []
-mesh_2D = []

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -267,9 +267,17 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
                 particle_1.first_step = false;
             }
 
-            if options.mean_free_path_model == MeanFreePathModel::GASEOUS {
-                ffp *= -rand::random::<f64>().ln();
-            }
+            ffp *= match options.mean_free_path_model {
+                MeanFreePathModel::GASEOUS => -rand::random::<f64>().ln(),
+                MeanFreePathModel::LIQUID => 1.0,
+                MeanFreePathModel::THRESHOLD{density} => {
+                    if material.geometry.get_densities(x, y, z).iter().sum::<f64>() < density {
+                        -rand::random::<f64>().ln()
+                    } else {
+                        1.0
+                    }
+                }
+            };
 
             binary_collision_geometries.push(BinaryCollisionGeometry::new(phis_azimuthal[0], impact_parameter[0], ffp));
             return binary_collision_geometries;

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -66,6 +66,8 @@ pub enum MeanFreePathModel {
     LIQUID,
     /// Exponentially-distributed mean-free-paths for gases.
     GASEOUS,
+    /// Switch from gas (below threshold) to liquid (above threshold).
+    THRESHOLD{density: f64}
 }
 
 impl fmt::Display for MeanFreePathModel {
@@ -73,6 +75,7 @@ impl fmt::Display for MeanFreePathModel {
         match *self {
             MeanFreePathModel::LIQUID => write!(f, "Amorphous Solid/Liquid Model"),
             MeanFreePathModel::GASEOUS => write!(f, "Gaseous Model"),
+            MeanFreePathModel::THRESHOLD{density} => write!(f, "Gaseous if n0 < {}, Liquid/Amorphous Solid otherwise.", density)
         }
     }
 }


### PR DESCRIPTION
…l density less than the threshold density will be assumed to be gaseous, with all other cells assumed amorphous solid/liquid.

Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #60

## Description
Implements `THRESHOLD{density: f64}` mean free path mode. This mode will use gaseous for any GeometryElement (e.g., Cell2D) that has a total number density below the threshold density in 1/m^3.

## Tests
cargo test has run, and the new mode has been tested with a number of input files.