### PR TITLE
Mesh 1d

### DIFF
--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -26,7 +26,6 @@ jobs:
         sudo apt-get install python3-pip
     - name: Install Python libraries
       run: |
-        pip3
         python3 -m pip install numpy shapely scipy
     - name: Install python TOML library from source
       run: |
@@ -41,7 +40,8 @@ jobs:
         cargo test --features cpr_rootfinder_netlib,hdf5_input
     - name: Run Examples
       run: |
-        cargo run --release examples/boron_nitride.toml
         cargo run --release 0D examples/boron_nitride_0D.toml
-        cargo run --release 0D examples/titanium_dioxide_0D.toml
-        cargo run --release --features distributions examples/layered_geometry.toml
+        ./target/relesae/rustBCA --release 0D examples/titanium_dioxide_0D.toml
+        ./target/relesae/rustBCA --release 1D --features distributions examples/layered_geometry.toml
+        ./target/relesae/rustBCA --release examples/boron_nitride.toml
+        ./target/relesae/rustBCA --release --features distributions examples/layered_geometry.toml

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -40,7 +40,7 @@ jobs:
         cargo test --features cpr_rootfinder_netlib,hdf5_input
     - name: Run Examples
       run: |
-        cargo run --release --features distributions 0D examples/boron_nitride_0D.toml
+        cargo run --release 0D examples/boron_nitride_0D.toml
         ./target/release/rustBCA 0D examples/titanium_dioxide_0D.toml
         ./target/release/rustBCA 1D examples/layered_geometry.toml
         ./target/release/rustBCA examples/boron_nitride.toml

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Run Examples
       run: |
         cargo run --release 0D examples/boron_nitride_0D.toml
-        ./target/relesae/rustBCA --release 0D examples/titanium_dioxide_0D.toml
-        ./target/relesae/rustBCA --release 1D --features distributions examples/layered_geometry.toml
-        ./target/relesae/rustBCA --release examples/boron_nitride.toml
-        ./target/relesae/rustBCA --release --features distributions examples/layered_geometry.toml
+        ./target/release/rustBCA --release 0D examples/titanium_dioxide_0D.toml
+        ./target/release/rustBCA --release 1D --features distributions examples/layered_geometry.toml
+        ./target/release/rustBCA --release examples/boron_nitride.toml
+        ./target/release/rustBCA --release --features distributions examples/layered_geometry.toml

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -42,6 +42,6 @@ jobs:
       run: |
         cargo run --release 0D examples/boron_nitride_0D.toml
         ./target/release/rustBCA 0D examples/titanium_dioxide_0D.toml
-        ./target/release/rustBCA 1D examples/layered_geometry.toml
+        ./target/release/rustBCA 1D examples/layered_geometry_1D.toml
         ./target/release/rustBCA examples/boron_nitride.toml
         ./target/release/rustBCA examples/layered_geometry.toml

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -40,8 +40,8 @@ jobs:
         cargo test --features cpr_rootfinder_netlib,hdf5_input
     - name: Run Examples
       run: |
-        cargo run --release 0D examples/boron_nitride_0D.toml
-        ./target/release/rustBCA --release 0D examples/titanium_dioxide_0D.toml
-        ./target/release/rustBCA --release 1D --features distributions examples/layered_geometry.toml
-        ./target/release/rustBCA --release examples/boron_nitride.toml
-        ./target/release/rustBCA --release --features distributions examples/layered_geometry.toml
+        cargo run --release --features distributions 0D examples/boron_nitride_0D.toml
+        ./target/release/rustBCA 0D examples/titanium_dioxide_0D.toml
+        ./target/release/rustBCA 1D examples/layered_geometry.toml
+        ./target/release/rustBCA examples/boron_nitride.toml
+        ./target/release/rustBCA examples/layered_geometry.toml

--- a/examples/layered_geometry_1D.toml
+++ b/examples/layered_geometry_1D.toml
@@ -51,7 +51,7 @@ particle_input_filename = ""
 [geometry_input]
 length_unit = "MICRON"
 densities = [ [ 3.0e+10, 6.0e+10, 0.0, 0.0,], [ 0.0, 0.0, 6.026e+10, 0.0,], [ 0.0, 0.0, 0.0, 4.996e+10,],]
-layer_thicknesses = [0.01, 0.04, 0.5]
+layer_thicknesses = [0.01, 0.03, 0.46]
 electronic_stopping_correction_factors = [1.0, 1.0, 1.0]
 
 [material_parameters]

--- a/examples/layered_geometry_1D.toml
+++ b/examples/layered_geometry_1D.toml
@@ -1,5 +1,5 @@
 [options]
-name = "2000.0eV_0.0001deg_He_TiO2"
+name = "2000.0eV_0.0001deg_He_TiO2_Al_Si"
 track_trajectories = false
 track_recoils = true
 track_recoil_trajectories = false
@@ -8,7 +8,7 @@ weak_collision_order = 3
 suppress_deep_recoils = false
 high_energy_free_flight_paths = false
 electronic_stopping_mode = "LOW_ENERGY_NONLOCAL"
-mean_free_path_model = {"THRESHOLD"={density=1E28}}
+mean_free_path_model = "LIQUID"
 interaction_potential = [["KR_C"]]
 scattering_integral = [["MENDENHALL_WELLER"]]
 use_hdf5 = false
@@ -44,14 +44,15 @@ E = [ 2000.0,]
 Ec = [ 1.0,]
 Es = [ 0.0,]
 interaction_index = [0]
-pos = [ [ 0.0, 0.0, 0.0,],]
-dir = [ [ 0.5, 0.5, 0.0,],]
+pos = [ [ -1.7453292519934434e-8, 0.0, 0.0,],]
+dir = [ [ 0.999, 0.001, 0.0,],]
 particle_input_filename = ""
 
 [geometry_input]
 length_unit = "MICRON"
-densities = [ 3.0e+10, 6.0e+10, 0.0, 0.0 ]
-electronic_stopping_correction_factor = 1.0
+densities = [ [ 3.0e+10, 6.0e+10, 0.0, 0.0,], [ 0.0, 0.0, 6.026e+10, 0.0,], [ 0.0, 0.0, 0.0, 4.996e+10,],]
+layer_thicknesses = [0.01, 0.04, 0.5]
+electronic_stopping_correction_factors = [1.0, 1.0, 1.0]
 
 [material_parameters]
 energy_unit = "EV"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,13 +1,15 @@
 use super::*;
 
 pub enum MaterialType {
-    MESH0D(material::Material<mesh::Mesh0D>),
-    MESH2D(material::Material<mesh::Mesh2D>)
+    MESH0D(material::Material<geometry::Mesh0D>),
+    MESH1D(material::Material<geometry::Mesh1D>),
+    MESH2D(material::Material<geometry::Mesh2D>)
 }
 
 #[derive(Deserialize)]
 pub enum GeometryType {
     MESH0D,
+    MESH1D,
     MESH2D,
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,11 +18,11 @@ pub struct Input2D {
     pub options: Options,
     pub material_parameters: material::MaterialParameters,
     pub particle_parameters: particle::ParticleParameters,
-    pub geometry_input: mesh::Mesh2DInput,
+    pub geometry_input: geometry::Mesh2DInput,
 }
 
 impl GeometryInput for Input2D {
-    type GeometryInput = mesh::Mesh2DInput;
+    type GeometryInput = geometry::Mesh2DInput;
 }
 
 impl InputFile for Input2D {
@@ -50,16 +50,48 @@ pub struct Input0D {
     pub options: Options,
     pub material_parameters: material::MaterialParameters,
     pub particle_parameters: particle::ParticleParameters,
-    pub geometry_input: mesh::Mesh0DInput,
+    pub geometry_input: geometry::Mesh0DInput,
 }
 
 impl GeometryInput for Input0D {
-    type GeometryInput = mesh::Mesh0DInput;
+    type GeometryInput = geometry::Mesh0DInput;
 }
 
 impl InputFile for Input0D {
 
     fn new(string: &str) -> Input0D {
+        toml::from_str(string).expect("Could not parse TOML file.")
+    }
+
+    fn get_options(&self) -> &Options{
+        &self.options
+    }
+    fn get_material_parameters(&self) -> &material::MaterialParameters{
+        &self.material_parameters
+    }
+    fn get_particle_parameters(&self) ->& particle::ParticleParameters{
+        &self.particle_parameters
+    }
+    fn get_geometry_input(&self) -> &Self::GeometryInput{
+        &self.geometry_input
+    }
+}
+
+#[derive(Deserialize, Clone)]
+pub struct Input1D {
+    pub options: Options,
+    pub material_parameters: material::MaterialParameters,
+    pub particle_parameters: particle::ParticleParameters,
+    pub geometry_input: geometry::Mesh1DInput,
+}
+
+impl GeometryInput for Input1D {
+    type GeometryInput = geometry::Mesh1DInput;
+}
+
+impl InputFile for Input1D {
+
+    fn new(string: &str) -> Input1D {
         toml::from_str(string).expect("Could not parse TOML file.")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ pub mod particle;
 pub mod tests;
 pub mod interactions;
 pub mod bca;
-pub mod mesh;
+pub mod geometry;
 pub mod input;
 pub mod output;
 pub mod enums;
@@ -62,9 +62,9 @@ pub mod structs;
 pub use crate::enums::*;
 pub use crate::consts::*;
 pub use crate::structs::*;
-pub use crate::input::{Input2D, Input0D, Options, InputFile, GeometryInput};
+pub use crate::input::{Input2D, Input1D, Input0D, Options, InputFile, GeometryInput};
 pub use crate::output::{OutputUnits};
-pub use crate::mesh::{Geometry, GeometryElement, Mesh0D, Mesh2D};
+pub use crate::geometry::{Geometry, GeometryElement, Mesh0D, Mesh1D, Mesh2D};
 
 fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::ParticleInput>, material: material::Material<T>, options: Options, output_units: OutputUnits) {
 
@@ -151,17 +151,21 @@ fn main() {
     let (input_file, geometry_type) = match args.len() {
         1 => ("input.toml".to_string(), GeometryType::MESH2D),
         2 => (args[1].clone(), GeometryType::MESH2D),
-        3 => (args[2].clone(), match args[1].as_str() { "0D" => GeometryType::MESH0D, "2D" => GeometryType::MESH2D, _ => panic!("Unimplemented geometry {}.", args[1].clone()) }),
+        3 => (args[2].clone(), match args[1].as_str() { "0D" => GeometryType::MESH0D, "1D" => GeometryType::MESH1D, "2D" => GeometryType::MESH2D, _ => panic!("Unimplemented geometry {}.", args[1].clone()) }),
         _ => panic!("Too many command line arguments. RustBCA accepts 0 (use 'input.toml') 1 (<input file name>) or 2 (<geometry type> <input file name>)"),
     };
 
      match geometry_type {
         GeometryType::MESH0D => {
-            let (particle_input_array, material, options, output_units) = input::input::<mesh::Mesh0D>(input_file);
+            let (particle_input_array, material, options, output_units) = input::input::<geometry::Mesh0D>(input_file);
             physics_loop::<Mesh0D>(particle_input_array, material, options, output_units);
         },
+        GeometryType::MESH1D => {
+            let (particle_input_array, material, options, output_units) = input::input::<geometry::Mesh1D>(input_file);
+            physics_loop::<Mesh1D>(particle_input_array, material, options, output_units);
+        },
         GeometryType::MESH2D => {
-            let (particle_input_array, material, options, output_units) = input::input::<mesh::Mesh2D>(input_file);
+            let (particle_input_array, material, options, output_units) = input::input::<geometry::Mesh2D>(input_file);
             physics_loop::<Mesh2D>(particle_input_array, material, options, output_units);
         },
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -33,7 +33,7 @@ fn test_geometry() {
     let thickness: f64 = 1000.;
     let depth: f64 = 1000.;
 
-    let geometry_input_2D = mesh::Mesh2DInput {
+    let geometry_input_2D = geometry::Mesh2DInput {
         length_unit: "ANGSTROM".to_string(),
         triangles: vec![(0., depth, 0., thickness/2., thickness/2., -thickness/2.), (depth, depth, 0., thickness/2., -thickness/2., -thickness/2.)],
         densities: vec![vec![0.03, 0.03], vec![0.03, 0.03]],
@@ -43,14 +43,14 @@ fn test_geometry() {
         electronic_stopping_correction_factors: vec![1.0, 1.0],
     };
 
-    let geometry_input_0D = mesh::Mesh0DInput {
+    let geometry_input_0D = geometry::Mesh0DInput {
         length_unit: "ANGSTROM".to_string(),
         densities: vec![0.03, 0.03],
         electronic_stopping_correction_factor: 1.0
     };
 
-    let material_2D: material::Material<mesh::Mesh2D> = material::Material::<mesh::Mesh2D>::new(&material_parameters, &geometry_input_2D);
-    let mut material_0D: material::Material<mesh::Mesh0D> = material::Material::<mesh::Mesh0D>::new(&material_parameters, &geometry_input_0D);
+    let material_2D: material::Material<geometry::Mesh2D> = material::Material::<geometry::Mesh2D>::new(&material_parameters, &geometry_input_2D);
+    let mut material_0D: material::Material<geometry::Mesh0D> = material::Material::<geometry::Mesh0D>::new(&material_parameters, &geometry_input_0D);
     material_0D.geometry.energy_barrier_thickness = 10.*ANGSTROM;
 
     particle_1.pos.x = 500.*ANGSTROM;
@@ -99,7 +99,7 @@ fn test_surface_binding_energy_barrier() {
     let thickness: f64 = 1000.;
     let depth: f64 = 1000.;
 
-    let geometry_input_2D = mesh::Mesh2DInput {
+    let geometry_input_2D = geometry::Mesh2DInput {
         length_unit: "ANGSTROM".to_string(),
         triangles: vec![(0., depth, 0., thickness/2., thickness/2., -thickness/2.), (depth, depth, 0., thickness/2., -thickness/2., -thickness/2.)],
         densities: vec![vec![0.03, 0.03], vec![0.03, 0.03]],
@@ -109,14 +109,14 @@ fn test_surface_binding_energy_barrier() {
         electronic_stopping_correction_factors: vec![1.0, 1.0],
     };
 
-    let geometry_input_0D = mesh::Mesh0DInput {
+    let geometry_input_0D = geometry::Mesh0DInput {
         length_unit: "ANGSTROM".to_string(),
         densities: vec![0.03, 0.03],
         electronic_stopping_correction_factor: 1.0
     };
 
-    let material_2D: material::Material<mesh::Mesh2D> = material::Material::<mesh::Mesh2D>::new(&material_parameters, &geometry_input_2D);
-    let mut material_0D: material::Material<mesh::Mesh0D> = material::Material::<mesh::Mesh0D>::new(&material_parameters, &geometry_input_0D);
+    let material_2D: material::Material<geometry::Mesh2D> = material::Material::<geometry::Mesh2D>::new(&material_parameters, &geometry_input_2D);
+    let mut material_0D: material::Material<geometry::Mesh0D> = material::Material::<geometry::Mesh0D>::new(&material_parameters, &geometry_input_0D);
     material_0D.geometry.energy_barrier_thickness = 10.*ANGSTROM;
 
     particle_1.pos.x = 500.*ANGSTROM;
@@ -188,11 +188,11 @@ fn test_surface_binding_energy_barrier() {
 
 #[test]
 fn test_triangle_contains() {
-    let triangle_1 = mesh::Triangle2D::new((0., 2., 0., 2., 0., 0.));
+    let triangle_1 = geometry::Triangle2D::new((0., 2., 0., 2., 0., 0.));
     assert!(triangle_1.contains(0.5, 0.5));
     assert!(!triangle_1.contains(2., 2.));
 
-    let triangle_2 = mesh::Triangle2D::new((-2., 0., 0., 0., 0., -2.));
+    let triangle_2 = geometry::Triangle2D::new((-2., 0., 0., 0., 0., -2.));
     assert!(triangle_2.contains(-0.5, -0.5));
     assert!(!triangle_2.contains(0.5, 0.5));
     assert!(!triangle_2.contains(-2., -2.));
@@ -200,7 +200,7 @@ fn test_triangle_contains() {
 
 #[test]
 fn test_triangle_distance_to() {
-    let triangle_1 = mesh::Triangle2D::new((0., 2., 0., 2., 0., 0.));
+    let triangle_1 = geometry::Triangle2D::new((0., 2., 0., 2., 0., 0.));
     assert!(approx_eq!(f64, triangle_1.distance_to(-2., 0.), 2., epsilon=1E-12), "{}", triangle_1.distance_to(-2., 0.));
 
     assert!(approx_eq!(f64, triangle_1.distance_to(2., 2.), (2.0_f64).sqrt(), epsilon=1E-12), "{}", triangle_1.distance_to(2., 2.));
@@ -320,7 +320,7 @@ fn test_momentum_conservation() {
 
         let thickness: f64 = 1000.;
         let depth: f64 = 1000.;
-        let geometry_input = mesh::Mesh2DInput {
+        let geometry_input = geometry::Mesh2DInput {
             length_unit: "ANGSTROM".to_string(),
             triangles: vec![(0., depth, 0., thickness/2., thickness/2., -thickness/2.), (depth, depth, 0., thickness/2., -thickness/2., -thickness/2.)],
             densities: vec![vec![0.06306], vec![0.06306]],
@@ -330,7 +330,7 @@ fn test_momentum_conservation() {
             energy_barrier_thickness: 0.,
         };
 
-        let material_1: material::Material<mesh::Mesh2D> = material::Material::<mesh::Mesh2D>::new(&material_parameters, &geometry_input);
+        let material_1: material::Material<geometry::Mesh2D> = material::Material::<geometry::Mesh2D>::new(&material_parameters, &geometry_input);
 
         for high_energy_free_flight_paths in vec![true, false] {
             for potential in vec![InteractionPotential::KR_C, InteractionPotential::MOLIERE, InteractionPotential::ZBL, InteractionPotential::LENZ_JENSEN] {


### PR DESCRIPTION
## Description
This adds a Mesh1D geometry type, similar to SRIM's layers. Users specify layer thicknesses in order, and the code builds a layered target with finite depth. The target starts at x = 0.

## Tests
New unit tests should be written, but results so far are good for implantation distributions and sputtering/reflection compared to 2D.
