### PR TITLE
New bulk binding energy mode. User can now choose between average (ol…

### DIFF
--- a/examples/boron_nitride.toml
+++ b/examples/boron_nitride.toml
@@ -28,6 +28,7 @@ Z = [ 5, 7,]
 m = [ 10.811, 14,]
 interaction_index = [0, 0]
 surface_binding_model = "AVERAGE"
+bulk_binding_model = "AVERAGE"
 
 [particle_parameters]
 length_unit = "MICRON"

--- a/examples/boron_nitride_0D.toml
+++ b/examples/boron_nitride_0D.toml
@@ -28,6 +28,7 @@ Z = [ 5, 7,]
 m = [ 10.811, 14,]
 interaction_index = [0, 0]
 surface_binding_model = "AVERAGE"
+bulk_binding_model = "AVERAGE"
 
 [particle_parameters]
 length_unit = "MICRON"

--- a/examples/layered_geometry.toml
+++ b/examples/layered_geometry.toml
@@ -67,3 +67,4 @@ Z = [ 22, 8, 13, 14,]
 m = [ 47.867, 15.9994, 26.98, 28.08553,]
 interaction_index = [0, 0, 0, 0]
 surface_binding_model = "TARGET"
+bulk_binding_model = "AVERAGE"

--- a/examples/layered_geometry_1D.toml
+++ b/examples/layered_geometry_1D.toml
@@ -45,7 +45,7 @@ Ec = [ 1.0,]
 Es = [ 0.0,]
 interaction_index = [0]
 pos = [ [ -1.7453292519934434e-8, 0.0, 0.0,],]
-dir = [ [ 0.999, 0.001, 0.0,],]
+dir = [ [ 0.5, 0.5, 0.0,],]
 particle_input_filename = ""
 
 [geometry_input]
@@ -64,3 +64,4 @@ Z = [ 22, 8, 13, 14,]
 m = [ 47.867, 15.9994, 26.98, 28.08553,]
 interaction_index = [0, 0, 0, 0]
 surface_binding_model = "TARGET"
+bulk_binding_model = "AVERAGE"

--- a/examples/multiple_interaction_potentials.toml
+++ b/examples/multiple_interaction_potentials.toml
@@ -61,3 +61,4 @@ Z = [ 22, 8, 13, 14,]
 m = [ 47.867, 15.9994, 26.98, 28.08553,]
 interaction_index = [0, 0, 0, 0]
 surface_binding_model = "TARGET"
+bulk_binding_model = "AVERAGE"

--- a/examples/titanium_dioxide_0D.toml
+++ b/examples/titanium_dioxide_0D.toml
@@ -63,3 +63,4 @@ Z = [ 22, 8, 13, 14,]
 m = [ 47.867, 15.9994, 26.98, 28.08553,]
 interaction_index = [0, 0, 0, 0]
 surface_binding_model = "TARGET"
+bulk_binding_model = "AVERAGE"

--- a/scripts/rustbca.py
+++ b/scripts/rustbca.py
@@ -175,7 +175,8 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
         'Z': Zb,
         'm': Mb,
         'interaction_index': np.zeros(len(n), dtype=int),
-        'surface_binding_model': "AVERAGE"
+        'surface_binding_model': "AVERAGE",
+        'bulk_binding_model': "AVERAGE"
     }
 
     dx = delta_x_angstrom*ANGSTROM/MICRON
@@ -184,7 +185,7 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
     surface = box(minx, miny, maxx, maxy)
 
     simulation_surface = surface.buffer(10*dx, cap_style=2, join_style=2)
-    mesh_2d_input = {
+    geometry_input = {
         'length_unit': 'MICRON',
         'triangles': [[0., depth, 0., thickness/2., -thickness/2., -thickness/2.], [0., depth, depth, thickness/2., thickness/2., -thickness/2.]],
         'densities': [np.array(n)*(MICRON)**3, np.array(n)*(MICRON)**3],
@@ -220,7 +221,7 @@ def generate_rustbca_input(Zb, Mb, n, Eca, Ecb, Esa, Esb, Eb, Ma, Za, E0, N, N_,
     input_file = {
         'material_parameters': material_parameters,
         'particle_parameters': particle_parameters,
-        'mesh_2d_input': mesh_2d_input,
+        'geometry_input': geometry_input,
         'options': options,
     }
 
@@ -748,6 +749,7 @@ def run_iead(ions, target, energies, angles, iead, name="default_", N=1):
         'm': Mb,
         'interaction_index': np.zeros(len(n), dtype=int),
         'surface_binding_model': "AVERAGE"
+        'bulk_binding_model': "AVERAGE"
     }
 
     dx = 5.*ANGSTROM/MICRON
@@ -756,7 +758,7 @@ def run_iead(ions, target, energies, angles, iead, name="default_", N=1):
     surface = box(minx, miny, maxx, maxy)
 
     simulation_surface = surface.buffer(10.*dx, cap_style=2, join_style=2)
-    mesh_2d_input = {
+    geometry_input = {
         'length_unit': 'MICRON',
         'energy_barrier_thickness': sum(n)**(-1./3.)/np.sqrt(2.*np.pi),
         'triangles': [[0., depth, 0., thickness/2., -thickness/2., -thickness/2.], [0., depth, depth, thickness/2., thickness/2., -thickness/2.]],
@@ -789,7 +791,7 @@ def run_iead(ions, target, energies, angles, iead, name="default_", N=1):
     input_file = {
         'material_parameters': material_parameters,
         'particle_parameters': particle_parameters,
-        'mesh_2d_input': mesh_2d_input,
+        'geometry_input': geometry_input,
         'options': options,
     }
 
@@ -1194,11 +1196,11 @@ def metal_oxide_bilayer_iead(ions, iead, energies, angles, metal,
         'Z': [metal['Z'], oxygen['Z']],
         'm': [metal['m'], oxygen['m']],
         'interaction_index': [0, 0],
-
+        'bulk_binding_model': "AVERAGE",
         'surface_binding_model': "AVERAGE"
     }
 
-    mesh_2d_input = {
+    geometry_input = {
         'length_unit': 'MICRON',
         'energy_barrier_thickness': sum(densities[0])**(-1./3.)/np.sqrt(2.*np.pi),
         'triangles': triangles,
@@ -1231,7 +1233,7 @@ def metal_oxide_bilayer_iead(ions, iead, energies, angles, metal,
     input_file = {
         'material_parameters': material_parameters,
         'particle_parameters': particle_parameters,
-        'mesh_2d_input': mesh_2d_input,
+        'geometry_input': geometry_input,
         'options': options,
     }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -61,6 +61,27 @@ impl fmt::Display for SurfaceBindingModel {
     }
 }
 
+/// Mode of bulk binding energy calculation.
+#[derive(Deserialize, PartialEq, Clone, Copy)]
+pub enum BulkBindingModel {
+    /// Bulk binding energies will be determined individually depending only on the particle's `Eb`.
+    INDIVIDUAL,
+    /// Bulk binding energies will be the concentration-weighted average, unless either is zero in which case it will be zero.
+    AVERAGE,
+}
+
+impl fmt::Display for BulkBindingModel {
+    fn fmt (&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BulkBindingModel::INDIVIDUAL => write!(f,
+                "Individual bulk binding energies."),
+
+            BulkBindingModel::AVERAGE => write!(f,
+                "Concentration-weighted average bulk binding energy."),
+        }
+    }
+}
+
 /// Mean-free-path model.
 #[derive(Deserialize, PartialEq, Clone, Copy)]
 pub enum MeanFreePathModel {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -27,7 +27,8 @@ fn test_geometry() {
         Z: vec![29., 1.],
         m: vec![63.54, 1.0008],
         interaction_index: vec![0, 0],
-        surface_binding_model: SurfaceBindingModel::TARGET
+        surface_binding_model: SurfaceBindingModel::TARGET,
+        bulk_binding_model: BulkBindingModel::INDIVIDUAL,
     };
 
     let thickness: f64 = 1000.;
@@ -93,7 +94,8 @@ fn test_surface_binding_energy_barrier() {
         Z: vec![29., 1.],
         m: vec![63.54, 1.0008],
         interaction_index: vec![0, 0],
-        surface_binding_model: SurfaceBindingModel::TARGET
+        surface_binding_model: SurfaceBindingModel::TARGET,
+        bulk_binding_model: BulkBindingModel::INDIVIDUAL,
     };
 
     let thickness: f64 = 1000.;
@@ -315,7 +317,8 @@ fn test_momentum_conservation() {
             Z: vec![Z2],
             m: vec![m2],
             interaction_index: vec![0],
-            surface_binding_model: SurfaceBindingModel::TARGET
+            surface_binding_model: SurfaceBindingModel::TARGET,
+            bulk_binding_model: BulkBindingModel::INDIVIDUAL,
         };
 
         let thickness: f64 = 1000.;


### PR DESCRIPTION
…d behavior) or individual (choose the bulk binding energy of that particular species).

Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #83

## Description
Added a new bulk binding energy mode. User can choose AVERAGE (average of bulk binding energies - previous behavior) or INDIVIDUAL (particle uses only its own bulk binding energy when created).

## Tests
All test have passed, and reflection coefficients/sputtering yields for the TiO2 case are correct.
