### PR TITLE
New surface refraction

### DIFF
--- a/src/material.rs
+++ b/src/material.rs
@@ -326,17 +326,13 @@ pub fn surface_binding_energy<T: Geometry>(particle_1: &mut particle::Particle, 
             let dy = y2 - y;
             let dz = z2 - z;
             let mag = (dx*dx + dy*dy + dz*dz).sqrt();
-
             let costheta = dx*cosx/mag + dy*cosy/mag + dz*cosz/mag;
-            //particle_1.E += Es;
 
             match material.surface_binding_model {
                 SurfaceBindingModel::PLANAR{..} => {
-                    //let delta_theta = particle::refraction_angle(costheta, E, E + Es);
-                    //particle::rotate_particle(particle_1, delta_theta, 0.);
                     particle::surface_refraction(particle_1, Vector::new(dx/mag, dy/mag, dz/mag), Es);
                 }
-                _ => ()
+                _ => particle.E += Es;
             }
         }
     }
@@ -358,16 +354,11 @@ pub fn surface_binding_energy<T: Geometry>(particle_1: &mut particle::Particle, 
         if costheta < 0. {
             if leaving_energy > Es {
 
-                //particle_1.E += -Es;
-
                 match material.surface_binding_model {
                     SurfaceBindingModel::PLANAR{..} => {
-                        //let delta_theta = particle::refraction_angle(costheta, E, E + Es);
-                        //particle::rotate_particle(particle_1, delta_theta, 0.);
-                        //println!("costheta: {}", costheta);
                         particle::surface_refraction(particle_1, Vector::new(-dx/mag, -dy/mag, -dz/mag), -Es);
                     }
-                    _ => ()
+                    _ => particle.E += -Es;
                 }
 
             } else {

--- a/src/material.rs
+++ b/src/material.rs
@@ -328,12 +328,13 @@ pub fn surface_binding_energy<T: Geometry>(particle_1: &mut particle::Particle, 
             let mag = (dx*dx + dy*dy + dz*dz).sqrt();
 
             let costheta = dx*cosx/mag + dy*cosy/mag + dz*cosz/mag;
-            particle_1.E += Es;
+            //particle_1.E += Es;
 
             match material.surface_binding_model {
                 SurfaceBindingModel::PLANAR{..} => {
-                    let delta_theta = particle::refraction_angle(costheta, E, E + Es);
-                    particle::rotate_particle(particle_1, delta_theta, 0.);
+                    //let delta_theta = particle::refraction_angle(costheta, E, E + Es);
+                    //particle::rotate_particle(particle_1, delta_theta, 0.);
+                    particle::surface_refraction(particle_1, Vector::new(dx/mag, dy/mag, dz/mag), Es);
                 }
                 _ => ()
             }
@@ -348,17 +349,23 @@ pub fn surface_binding_energy<T: Geometry>(particle_1: &mut particle::Particle, 
         let dz = z2 - z;
         let mag = (dx*dx + dy*dy + dz*dz).sqrt();
         let costheta = dx*cosx/mag + dy*cosy/mag + dz*cosz/mag;
-        let leaving_energy = E*costheta*costheta;
+
+        let leaving_energy = match material.surface_binding_model {
+            SurfaceBindingModel::ISOTROPIC{..} => E,
+            SurfaceBindingModel::PLANAR{..} => E*costheta*costheta,
+        };
 
         if costheta < 0. {
             if leaving_energy > Es {
 
-                particle_1.E += -Es;
+                //particle_1.E += -Es;
 
                 match material.surface_binding_model {
                     SurfaceBindingModel::PLANAR{..} => {
-                        let delta_theta = particle::refraction_angle(costheta, E, E + Es);
-                        particle::rotate_particle(particle_1, delta_theta, 0.);
+                        //let delta_theta = particle::refraction_angle(costheta, E, E + Es);
+                        //particle::rotate_particle(particle_1, delta_theta, 0.);
+                        //println!("costheta: {}", costheta);
+                        particle::surface_refraction(particle_1, Vector::new(-dx/mag, -dy/mag, -dz/mag), -Es);
                     }
                     _ => ()
                 }

--- a/src/material.rs
+++ b/src/material.rs
@@ -332,7 +332,7 @@ pub fn surface_binding_energy<T: Geometry>(particle_1: &mut particle::Particle, 
                 SurfaceBindingModel::PLANAR{..} => {
                     particle::surface_refraction(particle_1, Vector::new(dx/mag, dy/mag, dz/mag), Es);
                 }
-                _ => particle.E += Es;
+                _ => particle_1.E += Es,
             }
         }
     }
@@ -358,7 +358,7 @@ pub fn surface_binding_energy<T: Geometry>(particle_1: &mut particle::Particle, 
                     SurfaceBindingModel::PLANAR{..} => {
                         particle::surface_refraction(particle_1, Vector::new(-dx/mag, -dy/mag, -dz/mag), -Es);
                     }
-                    _ => particle.E += -Es;
+                    _ => particle_1.E += -Es,
                 }
 
             } else {

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -208,6 +208,28 @@ pub fn particle_advance(particle_1: &mut particle::Particle, mfp: f64, asymptoti
     return distance_traveled;
 }
 
+pub fn surface_refraction(particle: &mut Particle, normal: Vector, Es: f64) {
+    let E = particle.E;
+    let costheta = particle.dir.dot(&normal);
+    //println!("costheta: {}", costheta);
+
+    let a = (E/(E + Es)).sqrt();
+    let b = -(E).sqrt()*costheta;
+    let c = (E*costheta.powi(2) + Es).sqrt();
+    //println!("0: {} {} {}", particle.dir.x, particle.dir.y, particle.dir.z);
+    //println!("1: {} {} {}", a, b, c);
+
+    let u1x = (E/(E + Es)).sqrt()*particle.dir.x + ((-(E).sqrt()*costheta + (E*costheta.powi(2) + Es).sqrt())/(E + Es).sqrt())*normal.x;
+    let u1y = (E/(E + Es)).sqrt()*particle.dir.y + ((-(E).sqrt()*costheta + (E*costheta.powi(2) + Es).sqrt())/(E + Es).sqrt())*normal.y;
+    let u1z = (E/(E + Es)).sqrt()*particle.dir.z + ((-(E).sqrt()*costheta + (E*costheta.powi(2) + Es).sqrt())/(E + Es).sqrt())*normal.z;
+    particle.dir.x = u1x;
+    particle.dir.y = u1y;
+    particle.dir.z = u1z;
+    //println!("2: {} {} {}", particle.dir.x, particle.dir.y, particle.dir.z);
+
+    particle.E += Es;
+}
+
 /// Calcualte the refraction angle based on the surface binding energy of the material.
 pub fn refraction_angle(costheta: f64, energy_old: f64, energy_new: f64) -> f64 {
     let costheta = if costheta.abs() > 1. {costheta.signum()} else {costheta};

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -210,8 +210,9 @@ pub fn particle_advance(particle_1: &mut particle::Particle, mfp: f64, asymptoti
 
 pub fn surface_refraction(particle: &mut Particle, normal: Vector, Es: f64) {
     let E = particle.E;
-    let costheta = particle.dir.dot(&normal);
     
+    let costheta = particle.dir.dot(&normal);
+
     let a = (E/(E + Es)).sqrt();
     let b = -(E).sqrt()*costheta;
     let c = (E*costheta.powi(2) + Es).sqrt();

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -211,13 +211,10 @@ pub fn particle_advance(particle_1: &mut particle::Particle, mfp: f64, asymptoti
 pub fn surface_refraction(particle: &mut Particle, normal: Vector, Es: f64) {
     let E = particle.E;
     let costheta = particle.dir.dot(&normal);
-    //println!("costheta: {}", costheta);
-
+    
     let a = (E/(E + Es)).sqrt();
     let b = -(E).sqrt()*costheta;
     let c = (E*costheta.powi(2) + Es).sqrt();
-    //println!("0: {} {} {}", particle.dir.x, particle.dir.y, particle.dir.z);
-    //println!("1: {} {} {}", a, b, c);
 
     let u1x = (E/(E + Es)).sqrt()*particle.dir.x + ((-(E).sqrt()*costheta + (E*costheta.powi(2) + Es).sqrt())/(E + Es).sqrt())*normal.x;
     let u1y = (E/(E + Es)).sqrt()*particle.dir.y + ((-(E).sqrt()*costheta + (E*costheta.powi(2) + Es).sqrt())/(E + Es).sqrt())*normal.y;
@@ -225,8 +222,6 @@ pub fn surface_refraction(particle: &mut Particle, normal: Vector, Es: f64) {
     particle.dir.x = u1x;
     particle.dir.y = u1y;
     particle.dir.z = u1z;
-    //println!("2: {} {} {}", particle.dir.x, particle.dir.y, particle.dir.z);
-
     particle.E += Es;
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -38,6 +38,10 @@ impl Vector {
     pub fn add(&self, other: &Vector) -> Vector {
         Vector::new(self.x + other.x, self.y + other.y, self.z + other.z)
     }
+
+    pub fn dot(&self, other: &Vector) -> f64 {
+        self.x*other.x + self.y*other.y + self.z*other.z
+    }
 }
 
 /// Vector4 is a trajectory-tracking object that includes x, y, z, and the current energy.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -475,8 +475,11 @@ fn test_surface_refraction() {
     let cosy_new = cosy_new/dir_mag;
     let cosz_new = cosz_new/dir_mag;
 
-    let delta_theta = particle::refraction_angle(cosx, E, E + Es);
-    particle::rotate_particle(&mut particle_1, delta_theta, 0.);
+    //let delta_theta = particle::refraction_angle(cosx, E, E + Es);
+    //particle::rotate_particle(&mut particle_1, delta_theta, 0.);
+
+    let normal = Vector::new(1.0, 0.0, 0.0);
+    particle::surface_refraction(&mut particle_1, normal, Es);
 
     if print_output {
         println!("dir_mag: {}", dir_mag);
@@ -502,17 +505,22 @@ fn test_surface_refraction() {
         println!("{} {} {}", particle_1.dir.x, particle_1.dir.y, particle_1.dir.z);
     }
 
-    let delta_theta = particle::refraction_angle(particle_1.dir.x, particle_1.E, particle_1.E - Es);
-    particle::rotate_particle(&mut particle_1, delta_theta, 0.);
+    //let delta_theta = particle::refraction_angle(particle_1.dir.x, particle_1.E, particle_1.E - Es);
+    //particle::rotate_particle(&mut particle_1, delta_theta, 0.);
+
+    let normal = Vector::new(1.0, 0.0, 0.0);
+    particle::surface_refraction(&mut particle_1, normal, -Es);
+
 
     if print_output {
         println!("{} {} {}", cosx_new, cosy_new, cosz_new);
         println!("{} {} {}", particle_1.dir.x, particle_1.dir.y, particle_1.dir.z);
     }
 
-    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-12));
-    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-12));
-    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-12));
+    assert!(approx_eq!(f64, particle_1.dir.x, cosx_new, epsilon=1E-9));
+    assert!(approx_eq!(f64, particle_1.dir.y, cosy_new, epsilon=1E-9));
+    assert!(approx_eq!(f64, particle_1.dir.z, cosz_new, epsilon=1E-9));
+
 }
 
 #[test]


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #48

## Description
This includes a newly derived form for the surface refraction that does not rely on particle rotation. It should be much more robust than what was before, and it is easier to test.

## Tests
Modified tests in tests.rs and ran layered_geometry_1D to ensure that sputtering and sputtered yields stay the same. Would like to run more tests, this is a significant change.