### PR TITLE
Maintain backwards compat with surface binding models.

### DIFF
--- a/src/bca.rs
+++ b/src/bca.rs
@@ -406,11 +406,17 @@ fn distance_of_closest_approach(particle_1: &particle::Particle, particle_2: &pa
         Rootfinder::NEWTON{max_iterations, tolerance} => newton_rootfinder(Za, Zb, Ma, Mb, E0, p, interaction_potential, max_iterations, tolerance)
             .with_context(|| format!("Numerical error: Newton rootfinder failed for {} at {} eV with p = {} A.", interaction_potential, E0/EV, p/ANGSTROM))
             .unwrap(),
+        Rootfinder::DEFAULTNEWTON => newton_rootfinder(Za, Zb, Ma, Mb, E0, p, interaction_potential, 100, 1E-3)
+            .with_context(|| format!("Numerical error: Newton rootfinder failed for {} at {} eV with p = {} A.", interaction_potential, E0/EV, p/ANGSTROM))
+            .unwrap(),
     }
 
     #[cfg(not(any(feature = "cpr_rootfinder_openblas", feature = "cpr_rootfinder_netlib", feature = "cpr_rootfinder_intel_mkl")))]
     match root_finder {
         Rootfinder::NEWTON{max_iterations, tolerance} => newton_rootfinder(Za, Zb, Ma, Mb, E0, p, interaction_potential, max_iterations, tolerance)
+            .with_context(|| format!("Numerical error: Newton rootfinder failed for {} at {} eV with p = {} A.", interaction_potential, E0/EV, p/ANGSTROM))
+            .unwrap(),
+        Rootfinder::DEFAULTNEWTON => newton_rootfinder(Za, Zb, Ma, Mb, E0, p, interaction_potential, 100, 1E-3)
             .with_context(|| format!("Numerical error: Newton rootfinder failed for {} at {} eV with p = {} A.", interaction_potential, E0/EV, p/ANGSTROM))
             .unwrap(),
         _ => panic!("Input error: unimplemented root-finder. Choose NEWTON or build with cpr_rootfinder to enable CPR and POLYNOMIAL")

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -68,7 +68,11 @@ pub enum SurfaceBindingModel {
     /// Isotropic surface binding potential - results in no refraction
     ISOTROPIC{calculation: SurfaceBindingCalculation},
     /// Planar surface binding potential - particles refract through potential
-    PLANAR{calculation: SurfaceBindingCalculation}
+    PLANAR{calculation: SurfaceBindingCalculation},
+    /// Planar surface binding potential default - particles refract through potential
+    TARGET,
+    INDIVIDUAL,
+    AVERAGE
 }
 
 impl fmt::Display for SurfaceBindingModel {
@@ -78,6 +82,9 @@ impl fmt::Display for SurfaceBindingModel {
                 "Locally isotropic surface binding energy."),
             SurfaceBindingModel::PLANAR{..} => write!(f,
                 "Locally planar surface binding energy."),
+            SurfaceBindingModel::TARGET => write!(f, "Locally planar surface binding energy."),
+            SurfaceBindingModel::INDIVIDUAL =>write!(f, "Locally planar surface binding energy."),
+            SurfaceBindingModel::AVERAGE =>write!(f, "Locally planar surface binding energy."),
         }
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -217,6 +217,7 @@ pub enum Rootfinder {
     CPR{n0: usize, nmax: usize, epsilon: f64, complex_threshold: f64, truncation_threshold: f64,
         far_from_zero: f64, interval_limit: f64, derivative_free: bool},
     POLYNOMIAL{complex_threshold: f64},
+    DEFAULTNEWTON,
 }
 
 impl fmt::Display for Rootfinder {
@@ -226,6 +227,7 @@ impl fmt::Display for Rootfinder {
             Rootfinder::CPR{n0, nmax, epsilon, complex_threshold, truncation_threshold, far_from_zero, interval_limit, derivative_free} =>
                 write!(f, "Chebyshev-Proxy Rootfinder with {}-polishing", match derivative_free { true => "Secant", false => "Newton"}),
             Rootfinder::POLYNOMIAL{complex_threshold} => write!(f, "Frobenius Companion Matrix Polynomial Real Rootfinder with a complex tolerance of {}", complex_threshold),
+            Rootfinder::DEFAULTNEWTON => write!(f, "Newton-Raphson Rootfinder with maximum {} iterations and toleance = {}", 100, 1E-3),
         }
     }
 }


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #112 

## Description
Updated surface binding model to not require the enum.

## Tests
Cargo test has been run.