### PR TITLE
Geometry cleanup & ion acceleration fix

### DIFF
--- a/src/bca.rs
+++ b/src/bca.rs
@@ -85,11 +85,12 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
             let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material, &options);
 
             #[cfg(feature = "accelerated_ions")]
-            if !material.inside(particle_1.pos.x, particle_1.pos.y, particle_1.pos.z) {
+            let distance_to_target = if !material.inside(particle_1.pos.x, particle_1.pos.y, particle_1.pos.z) {
                 let (x, y, z) = material.geometry.closest_point(particle_1.pos.x, particle_1.pos.y, particle_1.pos.z);
-                let distance_to = ((x - particle_1.pos.x).powi(2) + (y - particle_1.pos.y).powi(2) + (z - particle_1.pos.z).powi(2)).sqrt();
-                mfp += distance_to;
-            }
+                ((x - particle_1.pos.x).powi(2) + (y - particle_1.pos.y).powi(2) + (z - particle_1.pos.z).powi(2)).sqrt()
+            } else {
+                0.
+            };
 
             let mut total_energy_loss = 0.;
             let mut total_asymptotic_deflection = 0.;
@@ -182,8 +183,13 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
             }
 
             //Advance particle in space and track total distance traveled
+            #[cfg(not(feature = "accelerated_ions"))]
             let distance_traveled = particle::particle_advance(&mut particle_1,
                 binary_collision_geometries[0].mfp, total_asymptotic_deflection);
+
+            #[cfg(feature = "accelerated_ions")]
+            let distance_traveled = particle::particle_advance(&mut particle_1,
+                binary_collision_geometries[0].mfp + distance_to_target, total_asymptotic_deflection);
 
             //Subtract total energy from all simultaneous collisions and electronic stopping
             bca::update_particle_energy(&mut particle_1, &material, distance_traveled,

--- a/src/material.rs
+++ b/src/material.rs
@@ -67,11 +67,7 @@ impl <T: Geometry + GeometryInput> Material<T> {
     /// Gets concentrations of triangle that contains or is nearest to (x, y)
     pub fn get_concentrations(&self, x: f64, y: f64, z: f64) -> Vec<f64> {
 
-        let total_number_density: f64 = if self.inside(x, y, z) {
-            self.geometry.get_total_density(x, y, z)
-        } else {
-            self.geometry.get_densities_nearest_to(x, y, z).iter().sum::<f64>()
-        };
+        let total_number_density: f64 = self.geometry.get_total_density(x, y, z);
 
         return self.geometry.get_densities(x, y, z).iter().map(|&i| i / total_number_density).collect();
     }
@@ -96,11 +92,7 @@ impl <T: Geometry + GeometryInput> Material<T> {
 
     /// Gets electronic stopping correction factor for LS and OR
     pub fn electronic_stopping_correction_factor(&self, x: f64, y: f64, z: f64) -> f64 {
-        if self.inside(x, y, z) {
-            return self.geometry.get_ck(x, y, z);
-        } else {
-            return self.geometry.get_ck_nearest_to(x, y, z);
-        }
+        return self.geometry.get_ck(x, y, z);
     }
 
     /// Determines the local mean free path from the formula sum(n(x, y))^(-1/3)
@@ -110,20 +102,12 @@ impl <T: Geometry + GeometryInput> Material<T> {
 
     /// Total number density of triangle that contains or is nearest to (x, y).
     pub fn total_number_density(&self, x: f64, y: f64, z: f64) -> f64 {
-        if self.inside(x, y, z) {
-            return self.geometry.get_densities(x, y, z).iter().sum::<f64>();
-        } else {
-            return self.geometry.get_densities_nearest_to(x, y, z).iter().sum::<f64>();
-        }
+        self.geometry.get_densities(x, y, z).iter().sum::<f64>()
     }
 
     /// Lists number density of each species of triangle that contains or is nearest to (x, y).
     pub fn number_densities(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
-        if self.inside(x, y, z) {
-            return &self.geometry.get_densities(x, y, z);
-        } else {
-            return &self.geometry.get_densities_nearest_to(x, y, z);
-        }
+        return &self.geometry.get_densities(x, y, z);
     }
 
     /// Determines whether a point (x, y) is inside the energy barrier of the material.

--- a/src/parry.rs
+++ b/src/parry.rs
@@ -106,12 +106,6 @@ impl Geometry for ParryBall {
     fn get_concentrations(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
         &self.concentrations
     }
-    fn get_densities_nearest_to(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
-        &self.densities
-    }
-    fn get_ck_nearest_to(&self, x: f64, y: f64, z: f64) -> f64 {
-        self.electronic_stopping_correction_factor
-    }
     fn inside(&self, x: f64, y: f64, z: f64) -> bool {
         let p = Point::new(x , y , z );
         self.ball.contains_local_point(&p)
@@ -240,12 +234,6 @@ impl Geometry for ParryTriMesh {
     }
     fn get_concentrations(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
         &self.concentrations
-    }
-    fn get_densities_nearest_to(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
-        &self.densities
-    }
-    fn get_ck_nearest_to(&self, x: f64, y: f64, z: f64) -> f64 {
-        self.electronic_stopping_correction_factor
     }
     fn inside(&self, x: f64, y: f64, z: f64) -> bool {
         inside_trimesh(&self.trimesh, x, y, z)

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -100,12 +100,6 @@ impl Geometry for Sphere {
     fn get_concentrations(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
         &self.concentrations
     }
-    fn get_densities_nearest_to(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
-        &self.densities
-    }
-    fn get_ck_nearest_to(&self, x: f64, y: f64, z: f64) -> f64 {
-        self.electronic_stopping_correction_factor
-    }
     fn inside(&self, x: f64, y: f64, z: f64) -> bool {
         let r = (x.powi(2) + y.powi(2) + z.powi(2)).sqrt();
         r < self.radius

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -486,8 +486,8 @@ fn test_geometry() {
     assert_eq!(material_2D.geometry.get_total_density(0., 0., 0.), material_0D.geometry.get_total_density(0., 0., 0.));
     assert_eq!(material_2D.geometry.get_concentrations(0., 0., 0.), material_0D.geometry.get_concentrations(0., 0., 0.));
     assert_eq!(material_2D.geometry.closest_point(-10., 0., 5.), material_0D.geometry.closest_point(-10., 0., 5.));
-    assert_eq!(material_2D.geometry.get_densities_nearest_to(-10., 0., 5.), material_0D.geometry.get_densities_nearest_to(-10., 0., 5.));
-    assert_eq!(material_2D.geometry.get_ck_nearest_to(-10., 0., 5.), material_0D.geometry.get_ck_nearest_to(-10., 0., 5.));
+    assert_eq!(material_2D.geometry.get_densities(-10., 0., 5.), material_0D.geometry.get_densities(-10., 0., 5.));
+    assert_eq!(material_2D.geometry.get_ck(-10., 0., 5.), material_0D.geometry.get_ck(-10., 0., 5.));
 }
 
 #[test]


### PR DESCRIPTION
Cleaned up the Geometry trait. There's no need to provide nearest_to_* functions - that should be handled by the * function alone. The only mesh that was using that functionality was Mesh2D, because of the separate boundary and cells.

Additionally, ion acceleration outside materials was fixed. By moving it out of the mfp calculation, it broke; this has been addressed.