### PR TITLE
Made sure progress bar always finishes, even for tiny simulations.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,7 @@ fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Particle
                     }).flatten()
                 );
             }
+            bar.finish();
 
             // Process this chunk of finished particles for output
             for particle in finished_particles {


### PR DESCRIPTION
Progress bar was not finishing for tiny simulations; added `bar.finish()` at end of BCA loop.