### PR TITLE
Made pyo3 optional.

### DIFF
--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -43,10 +43,10 @@ jobs:
         python3 -c "from libRustBCA.pybca import *; print(simple_bca_py)"
     - name: Test RustBCA
       run: |
-        cargo test --features cpr_rootfinder_netlib,hdf5_input,distributions,parry3d
+        sudo cargo test --features cpr_rootfinder_netlib,hdf5_input,distributions,parry3d
     - name: Run Examples
       run: |
-        cargo run --release 0D examples/boron_nitride_0D.toml
+        sudo cargo run --release 0D examples/boron_nitride_0D.toml
         ./target/release/RustBCA 0D examples/titanium_dioxide_0D.toml
         ./target/release/RustBCA 1D examples/layered_geometry_1D.toml
         cat 2000.0eV_0.0001deg_He_TiO2_Al_Sisummary.output
@@ -54,5 +54,5 @@ jobs:
         ./target/release/RustBCA examples/layered_geometry.toml
         cat 2000.0eV_0.0001deg_He_TiO2_Al_Sisummary.output
         ./target/release/RustBCA SPHERE examples/boron_nitride_sphere.toml
-        cargo run --release --features parry3d TRIMESH examples/tungsten_twist_trimesh.toml
+        sudo cargo run --release --features parry3d TRIMESH examples/tungsten_twist_trimesh.toml
         

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -35,6 +35,11 @@ jobs:
     - name: Install HDF5 Libraries
       run: |
         sudo apt install libhdf5-dev
+    - name: test Python Bindings
+      run: |
+        suto python3 -m pip install setuptools_rust testresources
+        sudo python3 setup.py install
+        python3 -c "from libRustBCA.pybca import *; print(simple_bca_py)"
     - name: Test RustBCA
       run: |
         cargo test --features cpr_rootfinder_netlib,hdf5_input,distributions,parry3d
@@ -49,3 +54,4 @@ jobs:
         cat 2000.0eV_0.0001deg_He_TiO2_Al_Sisummary.output
         ./target/release/RustBCA SPHERE examples/boron_nitride_sphere.toml
         cargo run --release --features parry3d TRIMESH examples/tungsten_twist_trimesh.toml
+        

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Run Examples
       run: |
         sudo cargo run --release 0D examples/boron_nitride_0D.toml
-        ./target/release/RustBCA 0D examples/titanium_dioxide_0D.toml
-        ./target/release/RustBCA 1D examples/layered_geometry_1D.toml
+        sudo ./target/release/RustBCA 0D examples/titanium_dioxide_0D.toml
+        sudo ./target/release/RustBCA 1D examples/layered_geometry_1D.toml
         cat 2000.0eV_0.0001deg_He_TiO2_Al_Sisummary.output
-        ./target/release/RustBCA examples/boron_nitride.toml
-        ./target/release/RustBCA examples/layered_geometry.toml
+        sudo ./target/release/RustBCA examples/boron_nitride.toml
+        sudo ./target/release/RustBCA examples/layered_geometry.toml
         cat 2000.0eV_0.0001deg_He_TiO2_Al_Sisummary.output
-        ./target/release/RustBCA SPHERE examples/boron_nitride_sphere.toml
+        sudo ./target/release/RustBCA SPHERE examples/boron_nitride_sphere.toml
         sudo cargo run --release --features parry3d TRIMESH examples/tungsten_twist_trimesh.toml
         

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install rust
       run: |
         curl --proto '=https' --tlsv1.2 -sSf -y https://sh.rustup.rs | sh
+        sudo apt-get install rustc
     - name: Install pip for Python-3
       run: |
         sudo apt-get install python3-pip

--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -37,7 +37,7 @@ jobs:
         sudo apt install libhdf5-dev
     - name: test Python Bindings
       run: |
-        suto python3 -m pip install setuptools_rust testresources
+        sudo python3 -m pip install setuptools_rust testresources
         sudo python3 setup.py install
         python3 -c "from libRustBCA.pybca import *; print(simple_bca_py)"
     - name: Test RustBCA

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ parry3d-f64 = {version = "0.2.0", optional = true}
 [dependencies.pyo3]
 version = "0.13.2"
 features = ["extension-module"]
+optional = true
 
 [dev-dependencies]
 float-cmp = "0.8.0"
@@ -51,3 +52,4 @@ distributions = ["ndarray"]
 no_list_output = []
 parry3d = ["parry3d-f64"]
 accelerated_ions = []
+python = ["pyo3"]

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,6 @@ setup(
     name="RustBCA",
     rust_extensions=[RustExtension("libRustBCA.pybca", binding=Binding.PyO3)],
     # rust extensions are not zip safe, just like C-extensions.
+    features=["python"]
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ from setuptools_rust import Binding, RustExtension
 
 setup(
     name="RustBCA",
-    rust_extensions=[RustExtension("libRustBCA.pybca", binding=Binding.PyO3)],
+    rust_extensions=[RustExtension("libRustBCA.pybca", binding=Binding.PyO3, features=["python"])],
     # rust extensions are not zip safe, just like C-extensions.
-    features=["python"],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ setup(
     name="RustBCA",
     rust_extensions=[RustExtension("libRustBCA.pybca", binding=Binding.PyO3)],
     # rust extensions are not zip safe, just like C-extensions.
-    features=["python"]
+    features=["python"],
     zip_safe=False,
 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,9 @@ use std::f64::consts::FRAC_2_SQRT_PI;
 use std::f64::consts::PI;
 use std::f64::consts::SQRT_2;
 
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
 use pyo3::wrap_pyfunction;
 
 //Load internal modules
@@ -70,6 +72,7 @@ pub use crate::sphere::{Sphere, SphereInput, InputSphere};
 #[cfg(feature = "parry3d")]
 pub use crate::parry::{ParryBall, ParryBallInput, InputParryBall, ParryTriMesh, ParryTriMeshInput, InputParryTriMesh};
 
+#[cfg(feature = "python")]
 #[pymodule]
 pub fn pybca(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(simple_bca_py, m)?)?;
@@ -467,11 +470,13 @@ pub extern "C" fn simple_bca_c(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64
     }
 }
 
+#[cfg(feature = "python")]
 #[pyfunction]
 pub fn simple_bca_py(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64, E1: f64, Z1: f64, m1: f64, Ec1: f64, Es1: f64, Z2: f64, m2: f64, Ec2: f64, Es2: f64, n2: f64, Eb2: f64) -> Vec<[f64; 9]> {
     simple_bca(x, y, z, ux, uy, uz, E1, Z1, m1, Ec1, Es1, Z2, m2, Ec2, Es2, n2, Eb2)
 }
 
+#[cfg(feature = "python")]
 #[pyfunction]
 pub fn simple_bca_list_py(energies: Vec<f64>, usx: Vec<f64>, usy: Vec<f64>, usz: Vec<f64>, Z1: f64, m1: f64, Ec1: f64, Es1: f64, Z2: f64, m2: f64, Ec2: f64, Es2: f64, n2: f64, Eb2: f64) -> Vec<[f64; 9]> {
 


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [x] Ensured all tests pass and added any necessary tests for new code

Fixes #143 

## Description
I've made the Python bindings optional - there is a linker error present on MacOS systems, and depending on PyO3 simply isn't necessary.

## Tests
Automatic testing has been done. An example C binary has been built without the Python libraries, following the instructions in the Wiki. Wiki needs to be updated still.