### PR TITLE
New feature: particle distributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rand = "0.8.3"
+rand_distr = "0.4.2"
 toml = "0.5.8"
 anyhow = "1.0.38"
 itertools = "0.10.0"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -11,6 +11,14 @@ pub enum MaterialType {
     TRIMESH(material::Material<parry::ParryTriMesh>)
 }
 
+#[derive(Deserialize, PartialEq, Clone, Copy)]
+#[serde(untagged)]
+pub enum Distributions {
+    UNIFORM{min: f64, max: f64},
+    NORMAL{mean: f64, std: f64},
+    POINT(f64),
+}
+
 #[derive(Deserialize)]
 pub enum GeometryType {
     MESH0D,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rand_distr::{Normal, Distribution, Uniform};
 
 pub trait InputFile: GeometryInput {
     fn new(string: &str) -> Self;
@@ -332,25 +333,53 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                 let Ec = particle_parameters.Ec[particle_index];
                 let Es = particle_parameters.Es[particle_index];
                 let interaction_index = particle_parameters.interaction_index[particle_index];
+
                 let (x, y, z) = particle_parameters.pos[particle_index];
                 let (cosx, cosy, cosz) = particle_parameters.dir[particle_index];
-                assert!(cosx < 1.,
-                    "Input error: particle x-direction cannot be exactly equal to 1 to avoid numerical gimbal lock.");
+                
                 for sub_particle_index in 0..N_ {
                     //Add new particle to particle vector
                     particle_input.push(
                         particle::ParticleInput{
                             m: m*mass_unit,
                             Z: Z,
-                            E: E*energy_unit,
+                            E: match E {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*energy_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*energy_unit},
+                                Distributions::POINT(x) => x*energy_unit,
+                            },
                             Ec: Ec*energy_unit,
                             Es: Es*energy_unit,
-                            x: x*length_unit,
-                            y: y*length_unit,
-                            z: z*length_unit,
-                            ux: cosx,
-                            uy: cosy,
-                            uz: cosz,
+                            x: match x {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            y: match y {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            z: match z {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            ux: match cosx {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => {assert!(x != 1.0, "ux cannot equal exactly 1.0 to prevent gimbal lock"); x*length_unit}
+                            },
+                            uy: match cosy {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            uz: match cosz {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
                             interaction_index: interaction_index,
                             tag: 0,
                             weight: 1.0,
@@ -379,8 +408,7 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                 let interaction_index = particle_parameters.interaction_index[particle_index];
                 let (x, y, z) = particle_parameters.pos[particle_index];
                 let (cosx, cosy, cosz) = particle_parameters.dir[particle_index];
-                assert!(cosx < 1.,
-                    "Input error: particle x-direction cannot be exactly equal to 1 to avoid numerical gimbal lock.");
+
                 for sub_particle_index in 0..N_ {
 
                     //Add new particle to particle vector
@@ -388,18 +416,46 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                         particle::ParticleInput{
                             m: m*mass_unit,
                             Z: Z,
-                            E: E*energy_unit,
+                            E: match E {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*energy_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*energy_unit},
+                                Distributions::POINT(x) => x*energy_unit,
+                            },
                             Ec: Ec*energy_unit,
                             Es: Es*energy_unit,
-                            x: x*length_unit,
-                            y: y*length_unit,
-                            z: z*length_unit,
-                            ux: cosx,
-                            uy: cosy,
-                            uz: cosz,
-                            interaction_index,
-                            weight: 1.0,
+                            x: match x {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            y: match y {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            z: match z {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            ux: match cosx {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => {assert!(x != 1.0, "ux cannot equal exactly 1.0 to prevent gimbal lock"); x*length_unit},
+                            },
+                            uy: match cosy {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            uz: match cosz {
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::POINT(x) => x*length_unit,
+                            },
+                            interaction_index: interaction_index,
                             tag: 0,
+                            weight: 1.0,
                         }
                     );
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,9 +43,6 @@ use std::f64::consts::FRAC_2_SQRT_PI;
 use std::f64::consts::PI;
 use std::f64::consts::SQRT_2;
 
-//rng
-//use rand::{Rng, thread_rng};
-
 //Load internal modules
 pub mod material;
 pub mod particle;

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -2,7 +2,6 @@ use super::*;
 
 /// Rustbca's internal representation of the particle_parameters input.
 
-
 #[cfg(feature = "hdf5_input")]
 #[derive(Deserialize, Clone)]
 pub struct ParticleParameters {
@@ -13,11 +12,11 @@ pub struct ParticleParameters {
     pub N: Vec<usize>,
     pub m: Vec<f64>,
     pub Z: Vec<f64>,
-    pub E: Vec<f64>,
+    pub E: Vec<Distributions>,
     pub Ec: Vec<f64>,
     pub Es: Vec<f64>,
-    pub pos: Vec<(f64, f64, f64)>,
-    pub dir: Vec<(f64, f64, f64)>,
+    pub pos: Vec<(Distributions, Distributions, Distributions)>,
+    pub dir: Vec<(Distributions, Distributions, Distributions)>,
     pub interaction_index: Vec<usize>,
 }
 
@@ -30,11 +29,11 @@ pub struct ParticleParameters {
     pub N: Vec<usize>,
     pub m: Vec<f64>,
     pub Z: Vec<f64>,
-    pub E: Vec<f64>,
+    pub E: Vec<Distributions>,
     pub Ec: Vec<f64>,
     pub Es: Vec<f64>,
-    pub pos: Vec<(f64, f64, f64)>,
-    pub dir: Vec<(f64, f64, f64)>,
+    pub pos: Vec<(Distributions, Distributions, Distributions)>,
+    pub dir: Vec<(Distributions, Distributions, Distributions)>,
     pub interaction_index: Vec<usize>,
 }
 


### PR DESCRIPTION
Thank you for your contribution to RustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [] Ensured all tests pass and added any necessary tests for new code

Fixes #153

## Description
This feature adds the ability to specify particle energies, directions, and positions using the backwards-compatible single points, or random distributions (for now, normal and uniform).

## Tests
Normal tests run; further testing TC before I merge.
