### PR TITLE
Remove generic import from anyhow - it was overriding Ok() and breaki…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ use std::{fmt};
 use std::mem::discriminant;
 
 //Error handling crate
-use anyhow::Result;
-use anyhow::*;
+use anyhow::{Result, Context, anyhow};
+//use anyhow::*;
 
 //Serializing/Deserializing crate
 use serde::*;
@@ -787,7 +787,7 @@ pub extern "C" fn compound_bca_list_c(input: InputCompoundBCA) -> OutputBCA {
 
 #[no_mangle]
 pub extern "C" fn compound_bca_list_fortran(num_incident_ions: &mut c_int, track_recoils: &mut bool,
-    ux: *mut f64, uy: *mut f64, uz: *mut f64, E1: *mut f64, 
+    ux: *mut f64, uy: *mut f64, uz: *mut f64, E1: *mut f64,
     Z1: *mut f64, m1: *mut f64, Ec1: *mut f64, Es1: *mut f64,
     num_species_target: &mut c_int,
     Z2: *mut f64, m2: *mut f64, Ec2: *mut f64, Es2: *mut f64, Eb2: *mut f64, n2: *mut f64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,7 @@ use std::mem::discriminant;
 use indicatif::{ProgressBar, ProgressStyle};
 
 //Error handling crate
-use anyhow::Result;
-use anyhow::*;
+use anyhow::{Result, Context, anyhow};
 
 //Serializing/Deserializing crate
 use serde::*;


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #166

## Description
Clarify imports from anyhow to stop overloading Ok().

## Tests
Compilation tested, and all tests run successfully. It was a compilation issue, so I'm not expecting any downstream effects.
