### PR TITLE
Testing pip as python build tool instead of directly invoking setup.py.

### DIFF
--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -42,8 +42,7 @@ jobs:
     - name: test Python Bindings
       run: |
         python3 -m pip install setuptools_rust testresources
-        python3 setup.py install --root .
-        cp -r usr/local/lib/python3.8/dist-packages/libRustBCA .
+        python3 -m pip install .
         python3 -c "from libRustBCA.pybca import *;"
     - name: Test Fortran and C bindings
       run : |


### PR DESCRIPTION
I'm changing the github workflow to use pip instead of directly invoking setup.py - the latter is deprecated, and hopefully this change fixes all the strange errors I've been running into using it.