### PR TITLE
Fix pmax in free-flight path routine; see issue #179.

### DIFF
--- a/src/bca.rs
+++ b/src/bca.rs
@@ -268,7 +268,7 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
 
             ffp = mfp;
             //Cylindrical geometry
-            pmax = mfp/SQRT2PI;
+            pmax = mfp/SQRTPI;
             let mut impact_parameter = Vec::with_capacity(1);
             let random_number = rand::random::<f64>();
             let p = pmax*random_number.sqrt();


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #179

## Description
Fix to pmax; change from factor of 1/sqrt(2pi) to 1/sqrt(pi) in free flight path routine.

## Tests
`cargo test` reports all tests working. I ran the 0D boron nitride example for the high and low energy cases, with interpolated electronic stopping for both, and the results are below. The fix does not appear to significantly affect the results at 1 keV, which is not unexpected, since the various geometries in Eckstein (cylindrical, spherical, planar) all have different pmaxes with little reported impact on overall results.

![after_fix](https://user-images.githubusercontent.com/37962344/155010989-e3769393-ba44-486c-8246-b5b546f673b7.png)
This is before the fix that affected ffp.
**NOTE**: I accidentally switched the colors. Doesn't impact the results.

![before_fix](https://user-images.githubusercontent.com/37962344/155010990-f340c959-b5a1-42e7-8404-dd8d6231764f.png)
And this is after. There is very little difference at 1 keV.
