### PR TITLE
Fix issue #193

### DIFF
--- a/examples/test_rustbca.py
+++ b/examples/test_rustbca.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import sys
 import os
 #This should allow the script to find materials and formulas from anywhere
-sys.path.append(os.path.dirname(__file__)+'../scripts')
+sys.path.append(os.path.dirname(__file__)+'/../scripts')
 sys.path.append('scripts')
 from materials import *
 from formulas import *


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [x] Opened an issue
- [x] Referenced the relevant issue number(s) below
- [x] Provided a description of the changes below
- [x] Ensured all tests pass and added any necessary tests for new code

Fixes #193

## Description
I have added the missing slash so that the search path is now valid and can be used to locate supporting modules.

## Tests
I have followed the steps mentioned in the issue, that is,

> Make a new directory, for example under /tmp, and then type python3 /full/path/to/rustbca/examples/test_rustbca.py to run the example.

After the fix, the example runs normally and gives the expected results.

OS: Fedora 36