### PR TITLE
Urgent fix: change default number of weak collisions to zero

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "RustBCA"
-version = "2.0.0"
+version = "2.0.1"
 default-run = "RustBCA"
 authors = ["Jon Drobny <drobny2@illinois.edu>", "Jon Drobny <jdrobny@tae.com>"]
 edition = "2018"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools_rust import Binding, RustExtension
 
 setup(
     name="RustBCA",
-    version="2.0.0",
+    version="2.0.1",
     rust_extensions=[
         RustExtension(
             "libRustBCA",

--- a/src/input.rs
+++ b/src/input.rs
@@ -141,6 +141,10 @@ fn three() -> usize {
     3
 }
 
+fn zero_usize() -> usize{
+    0
+}
+
 ///This helper function is a workaround to issue #368 in serde
 fn default_buffer_size() -> usize {
     8192
@@ -221,7 +225,7 @@ impl Options {
             track_recoils: track_recoils,
             track_recoil_trajectories: false,
             write_buffer_size: default_buffer_size(),
-            weak_collision_order: three(),
+            weak_collision_order: zero_usize(),
             suppress_deep_recoils: false,
             high_energy_free_flight_paths: false,
             electronic_stopping_mode: default_electronic_stopping_mode(),
@@ -302,7 +306,7 @@ impl Options {
             track_recoils: false,
             track_recoil_trajectories: false,
             write_buffer_size: default_buffer_size(),
-            weak_collision_order: three(),
+            weak_collision_order: zero_usize(),
             suppress_deep_recoils: false,
             high_energy_free_flight_paths: false,
             electronic_stopping_mode: default_electronic_stopping_mode(),


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #216 

## Description
This quick-fix for the unusual sputtering curves observed in issue #216 when Z1>>Z2 changes the default number of weak collisions to zero.
