### PR TITLE
Update rustbca_compile_check.yml

### DIFF
--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -30,12 +30,7 @@ jobs:
         sudo apt-get install python3-pip python3-dev
     - name: Install Python libraries
       run: |
-        python3 -m pip install numpy shapely scipy matplotlib
-    - name: Install python TOML library from source
-      run: |
-        git clone https://github.com/uiri/toml.git
-        cd toml
-        python3 setup.py install --root .
+        python3 -m pip install numpy shapely scipy matplotlib toml
     - name: Install HDF5 Libraries
       run: |
         sudo apt install libhdf5-dev


### PR DESCRIPTION
The TOML library on PyPi has been updated to include the numpy encoder, so there is no longer any need to build from the latest source. This patch just changes that part of the workflow, since it is currently throwing an exception.