### PR TITLE
Memory management

### DIFF
--- a/RustBCA.h
+++ b/RustBCA.h
@@ -130,6 +130,10 @@ extern "C" {
 
 OutputTaggedBCA compound_tagged_bca_list_c(InputTaggedBCA input);
 
+void drop_output_tagged_bca(OutputTaggedBCA output);
+
+void drop_output_bca(OutputBCA output);
+
 void reflect_single_ion_c(int *num_species_target,
                           double *ux,
                           double *uy,

--- a/examples/RustBCA.c
+++ b/examples/RustBCA.c
@@ -4,6 +4,7 @@
 
 int main(int argc, char * argv[]) {
   OutputTaggedBCA output;
+  OutputBCA output;
   double velocities[2][3] = {{500000.0, 0.1, 0.0}, {500000.0, 0.1, 0.0}};
   double positions[2][3] = {{0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}};
   int tags[2] = {0, 1};
@@ -51,6 +52,8 @@ int main(int argc, char * argv[]) {
   std::cout << output.particles[1][2];
   std::cout << std::endl;
 
+  drop_output_tagged_bca(output);
+  
   double nx = -0.707106;
   double ny = -0.707106;
   double nz = 0.0;

--- a/examples/RustBCA.c
+++ b/examples/RustBCA.c
@@ -4,7 +4,6 @@
 
 int main(int argc, char * argv[]) {
   OutputTaggedBCA output;
-  OutputBCA output;
   double velocities[2][3] = {{500000.0, 0.1, 0.0}, {500000.0, 0.1, 0.0}};
   double positions[2][3] = {{0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}};
   int tags[2] = {0, 1};
@@ -53,7 +52,7 @@ int main(int argc, char * argv[]) {
   std::cout << std::endl;
 
   drop_output_tagged_bca(output);
-  
+
   double nx = -0.707106;
   double ny = -0.707106;
   double nz = 0.0;


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #226 

## Description
It turns out that even if Rust forgets a raw pointer, it cannot be safely freed once C takes ownership. This PR adds a couple of cleanup functions that correctly dispose of structs with raw pointers when coupling to C to prevent memory leaking.

## Tests
cargo test passes and RustBCA.c was used with valgrind to show that this fixes the leak. See the linked issue above.
