### PR TITLE
Added warning when input includes zero-length electronic stopping cor…

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -66,6 +66,7 @@ impl Geometry for Mesh0D {
         let electronic_stopping_correction_factor = input.electronic_stopping_correction_factor;
 
         let densities: Vec<f64> = input.densities.iter().map(|element| element/(length_unit).powi(3)).collect();
+        assert!(densities.len() > 0, "Input Error: density list empty.");
 
         let total_density: f64 = densities.iter().sum();
 
@@ -135,6 +136,7 @@ impl Geometry for Mesh1D {
 
         let layer_thicknesses = geometry_input.layer_thicknesses.clone();
         let electronic_stopping_correction_factors = geometry_input.electronic_stopping_correction_factors.clone();
+        assert!(electronic_stopping_correction_factors.len() > 0, "Input Error: Electronic stopping correction factor list empty.");
         let n = layer_thicknesses.len();
 
         let mut layers: Vec<Layer1D> =  Vec::with_capacity(n);
@@ -433,7 +435,7 @@ impl Geometry for Mesh2D {
 
         let simulation_boundary_points = geometry_input.simulation_boundary_points.clone();
         let electronic_stopping_correction_factors = geometry_input.electronic_stopping_correction_factors.clone();
-
+        assert!(electronic_stopping_correction_factors.len() > 0, "Input Error: Electronic stopping correction factor list empty.");
         let n = triangles.len();
 
         let mut cells: Vec<Cell2D> =  Vec::with_capacity(n);


### PR DESCRIPTION
…rection factors.

Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #241 

## Description
This adds a warning when electronic stopping correction factor lists are empty.

## Tests
`cargo test` ran successfully with the changes.