### PR TITLE
Parallelized RustBCA python function for 0D compounds with tracking

### DIFF
--- a/examples/test_rustbca.py
+++ b/examples/test_rustbca.py
@@ -12,6 +12,7 @@ import time
 
 def main():
 
+
     #test rotation to and from RustBCA coordinates
 
     #nx, ny, nz is the normal vector (out of surface)
@@ -153,7 +154,7 @@ def main():
     print('Data processing complete.')
     print(f'RustBCA Y: {len(sputtered[:, 0])/number_ions} Yamamura Y: {yamamura_yield}')
     print(f'RustBCA R: {len(reflected[:, 0])/number_ions} Thomas R: {thomas}')
-    print(f'Time per ion: {delta_time/number_ions*1e3} us/{ion["symbol"]}')
+    print(f'Time per ion: {delta_time/number_ions} s/{ion["symbol"]}')
 
     #Next up is the layered target version. I'll add a 50 Angstrom layer of W-H to the top of the target.
 
@@ -199,11 +200,10 @@ def main():
     plt.plot([50.0, 50.0], [0.0, np.max(heights)*1.1])
     plt.gca().set_ylim([0.0, np.max(heights)*1.1])
 
-    #For smooth distributions and good statistics, you should use at least 10k ions
-    number_ions = 100
+    number_ions = 1000
 
     #1 keV is above the He on W sputtering threshold of ~150 eV
-    energies_eV = 1000.0*np.ones(number_ions)
+    energies_eV = 500.0*np.ones(number_ions)
 
     #Working with angles of exactly 0 is problematic due to gimbal lock
     angle = 0.0001
@@ -226,7 +226,7 @@ def main():
     output, incident, incident_index = compound_bca_list_tracked_py(
         energies_eV, ux, uy, uz, Z1, m1, Ec1, Es1,
         [target['Z'], ion['Z']], [target['m'], ion['m']],
-        [target['Ec'], ion['Ec']], [target['Es'], ion['Es']], [target['n']/10**30, target['n']/10**30],
+        [energies_eV[0], ion['Ec']], [target['Es'], ion['Es']], [target['n']/10**30, target['n']/10**30],
         [target['Eb'], 0.0])
     stop = time.time()
     delta_time = stop - start
@@ -238,7 +238,7 @@ def main():
     plt.legend(['Incident', 'Indicies'])
 
     output = np.array(output)
-    print('Simulation complete. Processing data...')
+    print(f'Simulation complete. It cost {(stop - start)}')
 
     plt.show()
 

--- a/examples/test_rustbca.py
+++ b/examples/test_rustbca.py
@@ -200,10 +200,10 @@ def main():
     plt.plot([50.0, 50.0], [0.0, np.max(heights)*1.1])
     plt.gca().set_ylim([0.0, np.max(heights)*1.1])
 
-    number_ions = 1000
+    number_ions = 10000
 
     #1 keV is above the He on W sputtering threshold of ~150 eV
-    energies_eV = 500.0*np.ones(number_ions)
+    energies_eV = 1000.0*np.ones(number_ions)
 
     #Working with angles of exactly 0 is problematic due to gimbal lock
     angle = 0.0001
@@ -218,7 +218,7 @@ def main():
     Ec1 = np.array([ion['Ec']]*number_ions)
     Es1 = np.array([ion['Es']]*number_ions)
 
-    print(f'Running tracked RustBCA for {number_ions} {ion["symbol"]} ions on {target["symbol"]} at {energies_eV[0]/1000.} keV...')
+    print(f'Running tracked RustBCA for {number_ions} {ion["symbol"]} ions on {target["symbol"]} with 1% {ion["symbol"]} at {energies_eV[0]/1000.} keV...')
     print(f'This may take several minutes.')
 
     start = time.time()
@@ -226,19 +226,53 @@ def main():
     output, incident, incident_index = compound_bca_list_tracked_py(
         energies_eV, ux, uy, uz, Z1, m1, Ec1, Es1,
         [target['Z'], ion['Z']], [target['m'], ion['m']],
-        [energies_eV[0], ion['Ec']], [target['Es'], ion['Es']], [target['n']/10**30, target['n']/10**30],
+        [target['Ec'], ion['Ec']], [target['Es'], ion['Es']], [target['n']/10**30, 0.01*target['n']/10**30],
         [target['Eb'], 0.0])
     stop = time.time()
     delta_time = stop - start
+
+    output = np.array(output)
+    Z = output[:, 0]
+    m = output[:, 1]
+    E = output[:, 2]
+    x = output[:, 3]
+    y = output[:, 4]
+    z = output[:, 5]
+    ux = output[:, 6]
+    uy = output[:, 7]
+    uz = output[:, 8]
+
+    #For the python bindings, these conditionals can be used to distinguish
+    #between sputtered, reflected, and implanted particles in the output list
+    sputtered = output[np.logical_and(Z == target['Z'], E > 0), :]
+    reflected = output[np.logical_and(Z == ion['Z'], x < 0), :]
+    implanted = output[np.logical_and(Z == ion['Z'], x > 0), :]
+
+    plt.figure(1)
+    plt.title(f'Sputtered {target["symbol"]} Energy Distribution')
+    plt.xlabel('E [eV]')
+    plt.ylabel('f(E) [A.U.]')
+    plt.hist(sputtered[:, 2], bins=100, density=True, histtype='step')
+
+    plt.figure(2)
+    plt.title(f'Implanted {ion["symbol"]} Depth Distribution')
+    plt.xlabel('x [A]')
+    plt.ylabel('f(x) [A.U.]')
+    plt.hist(implanted[:, 3], bins=100, density=True, histtype='step')
+
+    thomas = thomas_reflection(ion, target, energies_eV[0])
+    yamamura_yield = yamamura(ion, target, energies_eV[0])
+
+    print('Data processing complete.')
+    print(f'RustBCA Y: {len(sputtered[:, 0])/number_ions} Yamamura Y: {yamamura_yield}')
+    print(f'RustBCA R: {len(reflected[:, 0])/number_ions} Thomas R: {thomas}')
+    print(f'Time per ion: {delta_time/number_ions} s/{ion["symbol"]}')
 
     plt.figure()
     plt.plot(incident_index)
     plt.xlabel('Particle number')
     plt.ylabel('Particle index')
     plt.legend(['Incident', 'Indicies'])
-
-    output = np.array(output)
-    print(f'Simulation complete. It cost {(stop - start)}')
 
     plt.show()
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -965,8 +965,8 @@ pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f6
     assert_eq!(Eb2.len(), num_species_target, "Input error: list of target bulk binding energies is not the same length as atomic numbers.");
     assert_eq!(n2.len(), num_species_target, "Input error: list of target number densities is not the same length as atomic numbers.");
 
-    let mut options = Options::default_options(true);
-    options.high_energy_free_flight_paths = true;
+    let options = Options::default_options(true);
+    //options.high_energy_free_flight_paths = true;
 
     let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
     let y = 0.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub fn libRustBCA(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(simple_bca_py, m)?)?;
     m.add_function(wrap_pyfunction!(simple_bca_list_py, m)?)?;
     m.add_function(wrap_pyfunction!(compound_bca_list_py, m)?)?;
+    m.add_function(wrap_pyfunction!(compound_bca_list_tracked_py, m)?)?;
     m.add_function(wrap_pyfunction!(compound_bca_list_1D_py, m)?)?;
     m.add_function(wrap_pyfunction!(sputtering_yield, m)?)?;
     m.add_function(wrap_pyfunction!(reflection_coefficient, m)?)?;
@@ -916,6 +917,134 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
         index += 1;
     }
     (total_output, incident)
+}
+
+#[cfg(feature = "python")]
+///compound_tagged_bca_list_py(ux, uy,  uz, energy, Z1, m1, Ec1, Es1, Z2, m2, Ec2, Es2, n2, Eb2)
+/// runs a BCA simulation for a list of particles and outputs a list of sputtered, reflected, and implanted particles.
+/// Args:
+///    energies (list(f64)): initial ion energies in eV.
+///    ux (list(f64)): initial ion directions x. ux != 0.0 to avoid gimbal lock
+///    uy (list(f64)): initial ion directions y.
+///    uz (list(f64)): initial ion directions z.
+///    Z1 (list(f64)): initial ion atomic numbers.
+///    m1 (list(f64)): initial ion masses in amu.
+///    Ec1 (list(f64)): ion cutoff energies in eV. If ion energy < Ec1, it stops in the material.
+///    Es1 (list(f64)): ion surface binding energies. Assumed planar.
+///    Z2 (list(f64)): target material species atomic numbers.
+///    m2 (list(f64)): target material species masses in amu.
+///    Ec2 (list(f64)): target material species cutoff energies in eV. If recoil energy < Ec2, it stops in the material.
+///    Es2 (list(f64)): target species surface binding energies. Assumed planar.
+///    n2 (list(f64)): target material species atomic number densities in inverse cubic Angstroms.
+///    Eb2 (list(f64)): target material species bulk binding energies in eV.
+/// Returns:
+///    output (NX9 list of f64): each row in the list represents an output particle (implanted,
+///    sputtered, or reflected). Each row consists of:
+///      [Z, m (amu), E (eV), x, y, z, (angstrom), ux, uy, uz]
+///    incident (list(bool)): whether each row of output was an incident ion or originated in the target
+///    incident_index (list(usize)): index of incident particle that caused this particle to be emitted
+#[pyfunction]
+pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: Vec<f64>, Z1: Vec<f64>, m1: Vec<f64>, Ec1: Vec<f64>, Es1: Vec<f64>, Z2: Vec<f64>, m2: Vec<f64>, Ec2: Vec<f64>, Es2: Vec<f64>, n2: Vec<f64>, Eb2: Vec<f64>) -> (Vec<[f64; 9]>, Vec<bool>, Vec<usize>) {
+    let mut total_output = vec![];
+    let mut incident = vec![];
+    let mut incident_index = vec![];
+    let num_species_target = Z2.len();
+    let num_incident_ions = energies.len();
+
+    assert_eq!(ux.len(), num_incident_ions, "Input error: list of x-directions is not the same length as list of incident energies.");
+    assert_eq!(uy.len(), num_incident_ions, "Input error: list of y-directions is not the same length as list of incident energies.");
+    assert_eq!(uz.len(), num_incident_ions, "Input error: list of z-directions is not the same length as list of incident energies.");
+    assert_eq!(Z1.len(), num_incident_ions, "Input error: list of incident atomic numbers is not the same length as list of incident energies.");
+    assert_eq!(m1.len(), num_incident_ions, "Input error: list of incident atomic masses is not the same length as list of incident energies.");
+    assert_eq!(Es1.len(), num_incident_ions, "Input error: list of incident surface binding energies is not the same length as list of incident energies.");
+    assert_eq!(Ec1.len(), num_incident_ions, "Input error: list of incident cutoff energies is not the same length as list of incident energies.");
+
+    assert_eq!(m2.len(), num_species_target, "Input error: list of target atomic masses is not the same length as atomic numbers.");
+    assert_eq!(Ec2.len(), num_species_target, "Input error: list of target cutoff energies is not the same length as atomic numbers.");
+    assert_eq!(Es2.len(), num_species_target, "Input error: list of target surface binding energies is not the same length as atomic numbers.");
+    assert_eq!(Eb2.len(), num_species_target, "Input error: list of target bulk binding energies is not the same length as atomic numbers.");
+    assert_eq!(n2.len(), num_species_target, "Input error: list of target number densities is not the same length as atomic numbers.");
+
+    let options = Options::default_options(true);
+
+    let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
+    let y = 0.0;
+    let z = 0.0;
+
+    let material_parameters = material::MaterialParameters {
+        energy_unit: "EV".to_string(),
+        mass_unit: "AMU".to_string(),
+        Eb: Eb2,
+        Es: Es2,
+        Ec: Ec2,
+        Ed: vec![0.0; num_species_target],
+        Z: Z2,
+        m: m2,
+        interaction_index: vec![0; num_species_target],
+        surface_binding_model: SurfaceBindingModel::INDIVIDUAL,
+        bulk_binding_model: BulkBindingModel::INDIVIDUAL,
+    };
+
+    let geometry_input = geometry::Mesh0DInput {
+        length_unit: "ANGSTROM".to_string(),
+        densities: n2,
+        electronic_stopping_correction_factor: 1.0
+    };
+
+    let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
+
+    let mut index: usize = 0;
+    for (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_) in izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1) {
+
+        let mut energy_out;
+
+        let mut p = particle::Particle::default_incident(
+            m1_,
+            Z1_,
+            energy,
+            Ec1_,
+            Es1_,
+            x,
+            ux_,
+            uy_,
+            uz_
+        );
+
+        p.tag = index as i32;
+
+        let output = bca::single_ion_bca(p, &m, &options);
+
+        for particle in output {
+
+
+            if (particle.left) | (particle.incident) {
+
+                incident.push(particle.incident);
+                incident_index.push(particle.tag as usize);
+
+                if particle.stopped {
+                    energy_out = 0.
+                } else {
+                    energy_out = particle.E/EV
+                }
+                total_output.push(
+                    [
+                        particle.Z,
+                        particle.m/AMU,
+                        energy_out,
+                        particle.pos.x/ANGSTROM,
+                        particle.pos.y/ANGSTROM,
+                        particle.pos.z/ANGSTROM,
+                        particle.dir.x,
+                        particle.dir.y,
+                        particle.dir.z,
+                    ]
+                );
+            }
+        }
+        index += 1;
+    }
+    (total_output, incident, incident_index)
 }
 
 #[cfg(feature = "python")]


### PR DESCRIPTION
This PR adds a parallelized RustBCA python function, `compound_bca_list_tracked_py`. It is similar to `compound_bca_list_py`, but parallelized to as many threads are available and includes an additional output, `incident_by`, which gives the index of the incident particle any sputtered particles were sputtered by. This makes coupling to plasma models easier, as it lets the user introduce sputtered particles at the correct incident particle's location.

Documentation to come.