### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,11 @@ For those eager to get started with the standalone code, try running one of the 
 the plots located on the [Wiki], these may require some optional
 [Python] packages (`matplotlib`, `numpy`, `scipy`, `shapely`, and `toml`).
 
-### H trajectories and collision cascades in a boron nitride dust grain
-
+### H trajectories and collision cascades in boron nitride
 First, run the example using:
 
 ```bash
-cargo run --release examples/boron_nitride.toml
+cargo run --release 0D examples/boron_nitride_0D.toml
 ```
 
 Afterwords, fire up your favourite [Python] interpreter
@@ -73,7 +72,7 @@ Afterwords, fire up your favourite [Python] interpreter
 
 ```python
 from scripts.rustbca import *
-do_trajectory_plot("boron_dust_grain_")
+do_trajectory_plot("boron_nitride_")
 ```
 
 ### He implantation into a layered TiO<sub>2</sub>/Al/Si target

--- a/examples/boron_nitride_0D.toml
+++ b/examples/boron_nitride_0D.toml
@@ -13,7 +13,7 @@ mass_unit = "AMU"
 Eb = [ 0.0, 0.0,]
 Es = [ 5.76, 0.0,]
 Ed = [25.0, 25.0]
-Ec = [ 1.0, 1.0,]
+Ec = [ 5.0, 5.0,]
 Z = [ 5, 7,]
 m = [ 10.811, 14,]
 
@@ -21,7 +21,7 @@ m = [ 10.811, 14,]
 length_unit = "MICRON"
 energy_unit = "EV"
 mass_unit = "AMU"
-N = [ 100 ]
+N = [ 10 ] # Number of computational ions low for plotting trajectories
 m = [ 1.008 ]
 Z = [ 1 ]
 E = [ 1000.0 ]

--- a/examples/boron_nitride_0D.toml
+++ b/examples/boron_nitride_0D.toml
@@ -4,6 +4,8 @@ name = "boron_nitride_"
 weak_collision_order = 0
 num_threads = 4
 track_displacements = true
+track_trajectories = true
+track_recoil_trajectories = true
 
 [material_parameters]
 energy_unit = "EV"
@@ -19,7 +21,7 @@ m = [ 10.811, 14,]
 length_unit = "MICRON"
 energy_unit = "EV"
 mass_unit = "AMU"
-N = [ 10000 ]
+N = [ 100 ]
 m = [ 1.008 ]
 Z = [ 1 ]
 E = [ 1000.0 ]

--- a/examples/boron_nitride_wire_homogeneous.toml
+++ b/examples/boron_nitride_wire_homogeneous.toml
@@ -1,4 +1,4 @@
-#Use with 0D geometry option only
+#Use with HOMOGENEOUS2D geometry option only
 [options]
 name = "boron_nitride_h_"
 weak_collision_order = 0

--- a/src/input.rs
+++ b/src/input.rs
@@ -172,11 +172,6 @@ fn one_u64() -> u64 {
     1
 }
 
-///This helper function is a workaround to issue #368 in serde
-fn three() -> usize {
-    3
-}
-
 fn zero_usize() -> usize{
     0
 }


### PR DESCRIPTION
Also fixes example comment in 2D homogeneous case, and remove unused…code from default input options.

Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #273 

## Description
This PR updates the README to reflect the current status of the example input files, updates the Boron Nitride 0D example to work with trajectory plotting by reducing the number of samples and enabling trajectory tracking.

Since this is going directly on main, I am also using this opportunity to remove the unused three() function previously used as a default value for serde.

## Tests
Example was run using code snippet from the examples.
