### PR TITLE
Fix rotate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1502,10 +1502,10 @@ pub fn simple_compound_bca(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64, E1
 #[cfg(feature = "parry3d")]
 #[no_mangle]
 pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mut f64, uy: &mut f64, uz: &mut f64) {
-    const DELTA: f64 = 1e-9;
-    let RUSTBCA_DIRECTION: Vector3::<f64> = Vector3::<f64>::new(1.0, 0.0, 0.0);
+    //const DELTA: f64 = 1e-9;
+    //let RUSTBCA_DIRECTION: Vector3::<f64> = Vector3::<f64>::new(1.0, 0.0, 0.0);
 
-    let into_surface = Vector3::new(-nx, -ny, -nz);
+    //let into_surface = Vector3::new(-nx, -ny, -nz);
     let direction = Vector3::new(*ux, *uy, *uz);
 
     //Rotation to local RustBCA coordinates from global
@@ -1514,12 +1514,14 @@ pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mu
     //That rotation is then applied to the particle direction, and can be undone later.
     //Algorithm is from here:
     //https://math.stackexchange.com/questions/180418/calculate-rotation-matrix-to-align-vector-a-to-vector-b-in-3d/180436#180436
-    let v: Vector3<f64> = into_surface.cross(&RUSTBCA_DIRECTION);
-    let c = into_surface.dot(&RUSTBCA_DIRECTION);
-    let vx = Matrix3::<f64>::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0);
+    //let v: Vector3<f64> = into_surface.cross(&RUSTBCA_DIRECTION);
+    //let c = into_surface.dot(&RUSTBCA_DIRECTION);
+    //let vx = Matrix3::<f64>::new(0.0, -v.z, v.y, v.z, 0.0, -v.x, -v.y, v.x, 0.0);
 
-    let rotation_matrix = if (c + 1.0).abs() > 1e-6 {
-        Matrix3::identity() + vx + vx*vx/(1. + c)
+    let s = ny*ny + nz*nz;
+
+    let rotation_matrix = if nx > 0.0 {
+        Matrix3::<f64>::new(0.0, -ny, -nz, ny, nz*nz/s, -ny*nz/s, nz, -ny*nz/s, ny*ny/s)
     } else {
         //If c == -1.0, the correct rotation should simply be a 180 degree rotation
         //around a non-x axis; y is chosen arbitrarily
@@ -1531,12 +1533,12 @@ pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mu
     // ux must not be exactly 1.0 to avoid gimbal lock in RustBCA
     // simple_bca does not normalize direction before proceeding, must be done manually
     assert!(
-        incident.x + DELTA > 0.0, "Error: RustBCA initial direction out of surface. Please check surface normals and incident direction. c={} n = ({}, {}, {}) u = ({}, {}, {}), unew = ({}, {}, {})",
-        (c + 1.0).abs(), nx, ny, nz, ux, uy, uz, incident.x, incident.y, incident.z
+        incident.x > 0.0, "Error: RustBCA initial direction out of surface. Please check surface normals and incident direction. n = ({}, {}, {}) u = ({}, {}, {}), unew = ({}, {}, {})",
+        nx, ny, nz, ux, uy, uz, incident.x, incident.y, incident.z
     );
 
-    *ux = incident.x + DELTA;
-    *uy = incident.y - DELTA;
+    *ux = incident.x;
+    *uy = incident.y;
     *uz = incident.z;
     let mag = (ux.powf(2.) + uy.powf(2.) + uz.powf(2.)).sqrt();
 


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #284 

## Description
This PR does two things: 

1.  replaces computed linear algebra with a pre-computed rotation matrix for given n
2. removes panic from rotate_given_surface_normal

## Tests
Tested with the following script:
```
from libRustBCA import *
import numpy as np
delta = 1e-12
num_test = 1000000
mag = np.sqrt((1 - delta)**2 + delta**2)

nx = np.array([(1 - delta)/mag]*num_test)
ny = np.array([delta/mag]*num_test)
nz = np.array([0.0]*num_test)

ux = np.array([-delta]*num_test)
uy = np.random.uniform(-1, 1, num_test)
uz = np.random.uniform(-1, 1, num_test)
umag = np.sqrt(ux*ux + uy*uy + uz*uz)
ux /= umag
uy /= umag
uz /= umag

actually_incident = nx*ux + ny*uy + nz*uz < 0

ux2, uy2, uz2 = rotate_given_surface_normal_vec_py(nx[actually_incident], ny[actually_incident], nz[actually_incident], ux[actually_incident], uy[actually_incident], uz[actually_incident])
ux1, uy1, uz1 = rotate_back_vec_py(nx[actually_incident], ny[actually_incident], nz[actually_incident], ux2, uy2, uz2)

print(np.sum(ux1), np.sum(ux))
print(np.sum(uy1), np.sum(uy))
print(np.sum(uz1), np.sum(uz))
```