### PR TITLE
[WIP] Seeded RNG

### DIFF
--- a/.github/workflows/rustbca_compile_check.yml
+++ b/.github/workflows/rustbca_compile_check.yml
@@ -1,6 +1,7 @@
 name: RustBCA Compile check
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, dev ]
   pull_request:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-rand = "0.8.5"
-rand_distr = "0.4.3"
+rand = {version = "0.10.2", features=["chacha"]}
+rand_distr = "0.6.0"
 toml = "0.7.4"
 anyhow = "1.0.71"
 itertools = "0.10.5"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Follow these steps to install, build, and run simple RustBCA simulations
 for sputtering yields and reflection coefficients:
 ```
 git clone https://github.com/lcpp-org/rustbca
-git checkout branch rng_seeded
 cd rustbca
 python -m pip install .
 python

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ python -m pip install .
 python
 Python 3.9.6 (tags/v3.9.6:db3ff76, Jun 28 2021, 15:26:21) [MSC v.1929 64 bit (AMD64)] on win32
 Type "help", "copyright", "credits" or "license" for more information.
->>> from libRustBCA import *; from scripts.materials import *; import numpy as np
+>>> from libRustBCA import *; from scripts.materials import *; import numpy as np; import os
+>>> os.environ["RAYON_NUM_THREADS"] = "4"
 >>> angle = 0.0 # deg
 >>> energy = 1000.0 # eV
 >>> num_samples = 10000

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Afterwords, fire up your favourite [Python] interpreter
 from scripts.rustbca import *; import numpy as np;
 
 deposited_list = np.atleast_2d(np.genfromtxt('boron_nitride_deposited.output', delimiter=','))
-np.assert_approx_equal(deposited_list[0, 2], 0.016531847238600884)
+np.testing.assert_approx_equal(deposited_list[0, 2], 0.016531847238600884)
 
 do_trajectory_plot("boron_nitride_")
 ```
@@ -114,7 +114,7 @@ deposited_ions = np.genfromtxt(
     names=["M", "Z", "x", "y", "z", "collisions"],
 )
 
-np.assert_approx_equal(deposited_ions['x'][0], 0.0018110896054452609)
+np.testing.assert_approx_equal(deposited_ions['x'][0], 0.0018110896054452609)
 
 plt.hist(deposited_ions["x"], bins=100)
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ deposited_ions = np.genfromtxt(
     names=["M", "Z", "x", "y", "z", "collisions"],
 )
 
+np.assert_approx_equal(deposited_ions['x'][0], 0.0018110896054452609)
+
 plt.hist(deposited_ions["x"], bins=100)
 
 plt.show()

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Follow these steps to install, build, and run simple RustBCA simulations
 for sputtering yields and reflection coefficients:
 ```
 git clone https://github.com/lcpp-org/rustbca
+git checkout branch rng_seeded
 cd rustbca
 python -m pip install .
 python

--- a/README.md
+++ b/README.md
@@ -52,13 +52,12 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> angle = 0.0 # deg
 >>> energy = 1000.0 # eV
 >>> num_samples = 10000
->>> 1 < sputtering_yield(argon, tungsten, energy, angle, num_samples) < 1.1 # Y approx. 1.04
+>>> sputtering_yield(argon, tungsten, energy, angle, num_samples) == 1.032
 True
 >>> R_N, R_E = reflection_coefficient(argon, tungsten, energy, angle, num_samples)
->>> 0.3 < R_N < 0.4 # R_N approx. 0.35 
+>>> R_N == 0.3321
 True
->>> 0.0 < R_E < 0.2 # R_E approx 0.1
-True
+>>> np.testing.assert_approx_equal(R_E, 0.09839033536523972)
 ```
 
 For those eager to get started with the standalone code, try running one of the examples in the

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Python 3.9.6 (tags/v3.9.6:db3ff76, Jun 28 2021, 15:26:21) [MSC v.1929 64 bit (AM
 Type "help", "copyright", "credits" or "license" for more information.
 >>> from libRustBCA import *; from scripts.materials import *; import numpy as np; import os
 >>> os.environ["RAYON_NUM_THREADS"] = "4"
+>>> os.environ["LIBRUSTBCA_SEED"] = "0" # All multi-ion library functions default to a seed of 0; specified here for completeness
 >>> angle = 0.0 # deg
 >>> energy = 1000.0 # eV
 >>> num_samples = 10000

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> angle = 0.0 # deg
 >>> energy = 1000.0 # eV
 >>> num_samples = 10000
->>> sputtering_yield(argon, tungsten, energy, angle, num_samples) == 1.032
+>>> sputtering_yield(argon, tungsten, energy, angle, num_samples) == 1.0243
 True
 >>> R_N, R_E = reflection_coefficient(argon, tungsten, energy, angle, num_samples)
->>> R_N == 0.3321
+>>> R_N == 0.3234
 True
->>> np.testing.assert_approx_equal(R_E, 0.09839033536523972)
+>>> np.testing.assert_approx_equal(R_E, 0.09645129485419984)
 ```
 
 For those eager to get started with the standalone code, try running one of the examples in the
@@ -81,7 +81,11 @@ Afterwords, fire up your favourite [Python] interpreter
 (e.g., [IPython]) and execute:
 
 ```python
-from scripts.rustbca import *
+from scripts.rustbca import *; import numpy as np;
+
+deposited_list = np.atleast_2d(np.genfromtxt('boron_nitride_deposited.output', delimiter=','))
+np.assert_approx_equal(deposited_list[0, 2], 0.016531847238600884)
+
 do_trajectory_plot("boron_nitride_")
 ```
 

--- a/examples/test_rustbca.py
+++ b/examples/test_rustbca.py
@@ -12,6 +12,7 @@ import time
 
 def main():
 
+    os.environ["LIBRUSTBCA_SEED"]="0"
 
     #test rotation to and from RustBCA coordinates
 
@@ -76,14 +77,21 @@ def main():
     Y = sputtering_yield(ion, target, energy, angle, num_samples)
 
     print(f'Sputtering yield for {ion["symbol"]} on {target["symbol"]} at {energy} eV is {Y} at/ion. Yamamura predicts { np.round(yamamura(ion, target, energy),3)} at/ion.')
+    np.testing.assert_approx_equal(Y, 0.045)
+
 
     R_N, R_E = reflection_coefficient(ion, target, energy, angle, num_samples)
     print(f'Particle reflection coefficient for {ion["symbol"]} on {target["symbol"]} at {energy} eV is {R_N}. Thomas predicts {np.round(thomas_reflection(ion, target, energy), 3)}.')
     print(f'Energy reflection coefficient for {ion["symbol"]} on {target["symbol"]} at {energy} eV is {R_E}')
+    np.testing.assert_approx_equal(R_N, 0.435)
+    np.testing.assert_approx_equal(R_E, 0.23222361140889344)
 
     R_N, R_E = compound_reflection_coefficient(ion, [target, ion], [target['n'], 0.1*target['n']], energy, angle, num_samples)
     print(f'Particle reflection coefficient for {ion["symbol"]} on {ion["symbol"]}x{target["symbol"]} where x=0.1 at {energy} eV is {R_N}. Thomas predicts {np.round(thomas_reflection(ion, target, energy), 3)}.')
     print(f'Energy reflection coefficient for {ion["symbol"]}x{target["symbol"]} where x=0.1 at {energy} eV is {R_E}')
+    np.testing.assert_approx_equal(R_N, 0.421)
+    np.testing.assert_approx_equal(R_E, 0.22787000234654273)
+
 
     vx0 = 1e5
     vy0 = 1e5
@@ -112,6 +120,7 @@ def main():
 
     start = time.time()
     #Note that simple_bca_list_py expects number densities in 1/Angstrom^3
+    # Note - simple_bca_list_py is unseeded and nondeterministic
     output = np.array(simple_bca_list_py(energies_eV, ux, uy, uz, ion['Z'],
         ion['m'], ion['Ec'], ion['Es'], target['Z'], target['m'],
         target['Ec'], target['Es'], target['n']/10**30, target['Eb']))
@@ -129,6 +138,9 @@ def main():
     ux = output[:, 6]
     uy = output[:, 7]
     uz = output[:, 8]
+
+    # check that mean implantation depth is reasonable
+    assert(20, np.mean(x), 30)
 
     #For the python bindings, these conditionals can be used to distinguish
     #between sputtered, reflected, and implanted particles in the output list
@@ -155,6 +167,10 @@ def main():
     print(f'RustBCA Y: {len(sputtered[:, 0])/number_ions} Yamamura Y: {yamamura_yield}')
     print(f'RustBCA R: {len(reflected[:, 0])/number_ions} Thomas R: {thomas}')
     print(f'Time per ion: {delta_time/number_ions} s/{ion["symbol"]}')
+
+    # check that reflection/sputtering are reasonable
+    assert(0.01 < len(sputtered[:, 0])/number_ions < 0.03)
+    assert(0.4 < len(reflected[:, 0])/number_ions < 0.6)
 
     #Next up is the layered target version. I'll add a 50 Angstrom layer of W-H to the top of the target.
 
@@ -199,6 +215,8 @@ def main():
     heights, _, _ = plt.hist(x[np.logical_and(incident, stopped)], bins=100, density=True, histtype='step')
     plt.plot([50.0, 50.0], [0.0, np.max(heights)*1.1])
     plt.gca().set_ylim([0.0, np.max(heights)*1.1])
+
+    np.testing.assert_approx_equal(np.mean(x), 12.179891077431188)
 
     number_ions = 10000
 
@@ -267,6 +285,9 @@ def main():
     print(f'RustBCA Y: {len(sputtered[:, 0])/number_ions} Yamamura Y: {yamamura_yield}')
     print(f'RustBCA R: {len(reflected[:, 0])/number_ions} Thomas R: {thomas}')
     print(f'Time per ion: {delta_time/number_ions} s/{ion["symbol"]}')
+
+    np.testing.assert_approx_equal(len(sputtered[:, 0])/number_ions, 0.027)
+    np.testing.assert_approx_equal(len(reflected[:, 0])/number_ions, 0.5089)
 
     plt.figure()
     plt.plot(incident_index)

--- a/examples/test_rustbca.py
+++ b/examples/test_rustbca.py
@@ -140,7 +140,7 @@ def main():
     uz = output[:, 8]
 
     # check that mean implantation depth is reasonable
-    assert(20, np.mean(x), 30)
+    assert(20 < np.mean(x) < 30)
 
     #For the python bindings, these conditionals can be used to distinguish
     #between sputtered, reflected, and implanted particles in the output list
@@ -194,7 +194,6 @@ def main():
         [ion['m']]*number_ions, [ion['Ec']]*number_ions, [ion['Es']]*number_ions, [target['Z'], 1.0], [target['m'], 1.008],
         [target['Ec'], 1.0], [target['Es'], 1.5], [target['Eb'], 0.0], [[target['n']/10**30, target['n']/10**30], [target['n']/10**30, 0.0]], [50.0, 1e6]
     )
-
 
     output = np.array(output)
 

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -100,7 +100,7 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
             for (k, binary_collision_geometry) in binary_collision_geometries.iter().enumerate().take(options.weak_collision_order + 1) {
 
                 let (species_index, mut particle_2) = bca::choose_collision_partner(&particle_1, &material,
-                    &binary_collision_geometry, &options);
+                    &binary_collision_geometry, &options, rng);
 
                 //If recoil location is inside, proceed with binary collision loop
                 if material.inside(particle_2.pos.x, particle_2.pos.y, particle_2.pos.z) & material.inside_energy_barrier(particle_1.pos.x, particle_1.pos.y, particle_1.pos.z) {
@@ -348,7 +348,7 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
 }
 
 /// For a particle in a material, and for a particular binary collision geometry, choose a species for the collision partner.
-pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, material: &material::Material<T>, binary_collision_geometry: &BinaryCollisionGeometry, options: &Options) -> (usize, particle::Particle) {
+pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, material: &material::Material<T>, binary_collision_geometry: &BinaryCollisionGeometry, options: &Options, rng: &mut ChaCha8Rng) -> (usize, particle::Particle) {
     let x = particle_1.pos.x;
     let y = particle_1.pos.y;
     let z = particle_1.pos.z;
@@ -389,7 +389,7 @@ pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, ma
     };
 
     //Choose recoil Z, M
-    let (species_index, Z_recoil, M_recoil, Ec_recoil, Es_recoil, Ed_recoil, interaction_index) = material.choose(x_recoil, y_recoil, z_recoil);
+    let (species_index, Z_recoil, M_recoil, Ec_recoil, Es_recoil, Ed_recoil, interaction_index) = material.choose(x_recoil, y_recoil, z_recoil, rng);
     let mut new_particle = particle::Particle::new(
         M_recoil, Z_recoil, 0., Ec_recoil, Es_recoil, Ed_recoil,
         x_recoil, y_recoil, z_recoil,

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -538,7 +538,7 @@ pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &
 /// Mendenhall-Weller scattering integrand.
 fn scattering_integral_mw(x: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //Function for scattering integral - see Mendenhall and Weller, 1991 & 2005
-    return 1/(1. - interactions::phi(x, interaction_potential)/x/reduced_energy - beta*beta/x/x).sqrt();
+    return 1./(1. - interactions::phi(x, interaction_potential)/x/reduced_energy - beta*beta/x/x).sqrt();
 }
 
 /// Gauss-Legendre scattering integrand.

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -80,7 +80,7 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
         while !particle_1.stopped & !particle_1.left {
 
             //Choose impact parameters and azimuthal angles for all collisions, and determine mean free path
-            let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material, &options, rng);
+            let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, material, options, rng);
 
             #[cfg(feature = "accelerated_ions")]
             let distance_to_target = if !material.inside(particle_1.pos.x, particle_1.pos.y, particle_1.pos.z) {
@@ -99,15 +99,15 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
             //Collision loop
             for (k, binary_collision_geometry) in binary_collision_geometries.iter().enumerate().take(options.weak_collision_order + 1) {
 
-                let (species_index, mut particle_2) = bca::choose_collision_partner(&particle_1, &material,
-                    &binary_collision_geometry, &options, rng);
+                let (species_index, mut particle_2) = bca::choose_collision_partner(&particle_1, material,
+                    binary_collision_geometry, options, rng);
 
                 //If recoil location is inside, proceed with binary collision loop
                 if material.inside(particle_2.pos.x, particle_2.pos.y, particle_2.pos.z) & material.inside_energy_barrier(particle_1.pos.x, particle_1.pos.y, particle_1.pos.z) {
 
                     //Determine scattering angle from binary collision
                     let binary_collision_result = bca::calculate_binary_collision(&particle_1,
-                        &particle_2, &binary_collision_geometry, &options)
+                        &particle_2, binary_collision_geometry, options)
                         .with_context(|| format!("Numerical error: binary collision calculation failed at x = {} y = {} with {}",
                             particle_1.pos.x, particle_2.pos.x, &binary_collision_geometry))
                         .unwrap();
@@ -190,13 +190,13 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
                 binary_collision_geometries[0].mfp + distance_to_target - material.geometry.get_energy_barrier_thickness(), total_asymptotic_deflection);
 
             //Subtract total energy from all simultaneous collisions and electronic stopping
-            let energy_lost_to_electronic_stopping = bca::subtract_electronic_stopping_energy(&mut particle_1, &material, distance_traveled,
+            let energy_lost_to_electronic_stopping = bca::subtract_electronic_stopping_energy(&mut particle_1, material, distance_traveled,
                 normalized_distance_of_closest_approach, strong_collision_Z,
-                strong_collision_index, &options);
-            particle_1.update_energy_loss_tracker(&options, total_energy_lost_to_recoils, energy_lost_to_electronic_stopping);
+                strong_collision_index, options);
+            particle_1.update_energy_loss_tracker(options, total_energy_lost_to_recoils, energy_lost_to_electronic_stopping);
 
             //Check boundary conditions on leaving and stopping
-            material::boundary_condition_planar(&mut particle_1, &material);
+            material::boundary_condition_planar(&mut particle_1, material);
 
             //Set particle index to topmost particle
             particle_index = particles.len();
@@ -288,7 +288,7 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
             };
 
             binary_collision_geometries.push(BinaryCollisionGeometry::new(phis_azimuthal[0], impact_parameter[0], ffp));
-            return binary_collision_geometries;
+            binary_collision_geometries
 
         } else {
 
@@ -312,7 +312,7 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
             }
 
             binary_collision_geometries.push(BinaryCollisionGeometry::new(phis_azimuthal[0], impact_parameter[0], ffp));
-            return binary_collision_geometries;
+            binary_collision_geometries
         }
 
     } else {
@@ -343,7 +343,7 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
             binary_collision_geometries.push(BinaryCollisionGeometry::new(phis_azimuthal[k], impact_parameters[k], mfp))
         }
 
-        return binary_collision_geometries;
+        binary_collision_geometries
     }
 }
 
@@ -402,7 +402,7 @@ pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, ma
     new_particle.tag = particle_1.tag;
     new_particle.tracked_vector = particle_1.tracked_vector;
 
-    return (species_index, new_particle)
+    (species_index, new_particle)
 }
 
 /// Calculate the distance of closest approach of two particles given a particular binary collision geometry.
@@ -539,7 +539,7 @@ pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &
 /// Mendenhall-Weller scattering integrand.
 fn scattering_integral_mw(x: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //Function for scattering integral - see Mendenhall and Weller, 1991 & 2005
-    return 1./(1. - interactions::phi(x, interaction_potential)/x/reduced_energy - beta*beta/x/x).sqrt();
+    1./(1. - interactions::phi(x, interaction_potential)/x/reduced_energy - beta*beta/x/x).sqrt()
 }
 
 /// Gauss-Legendre scattering integrand.
@@ -579,8 +579,8 @@ fn scattering_integral_gauss_mehler(impact_parameter: f64, relative_energy: f64,
 
 /// Compute the scattering integral for a given relative energy, distance of closest approach `r0`,  and interaction potential using a Gauss-Legendre, 5-point quadrature.
 fn scattering_integral_gauss_legendre(impact_parameter: f64, relative_energy: f64, r0: f64, interaction_potential: &dyn Fn(f64) -> f64) -> f64 {
-    let x: Vec<f64> = vec![0., -0.538469, 0.538469, -0.90618, 0.90618].iter().map(|x| x/2. + 1./2.).collect();
-    let w: Vec<f64> = vec![0.568889, 0.478629, 0.478629, 0.236927, 0.236927].iter().map(|w| w/2.).collect();
+    let x: Vec<f64> = [0., -0.538469, 0.538469, -0.90618, 0.90618].iter().map(|x| x/2. + 1./2.).collect();
+    let w: Vec<f64> = [0.568889, 0.478629, 0.478629, 0.236927, 0.236927].iter().map(|w| w/2.).collect();
 
     PI - x.iter().zip(w)
         .map(|(&x, w)| w*scattering_function_gl(x, impact_parameter, r0, relative_energy, interaction_potential)
@@ -720,8 +720,8 @@ pub fn newton_rootfinder(Za: f64, Zb: f64, Ma: f64, Mb: f64, E0: f64, impact_par
             return Ok(x0);
         }
     }
-    return Err(anyhow!("Numerical error: exceeded maximum number of Newton-Raphson iterations, {}. E: {} eV; x0: {}; Error: {}; Tolerance: {}; Za: {}; Zb: {}; Ma: {} amu; Mb: {} amu; a: {}; p: {} A",
-        max_iterations, E0/Q, x0, err, tolerance, Za, Zb, Ma/AMU, Mb/AMU, a, impact_parameter/ANGSTROM));
+    Err(anyhow!("Numerical error: exceeded maximum number of Newton-Raphson iterations, {}. E: {} eV; x0: {}; Error: {}; Tolerance: {}; Za: {}; Zb: {}; Ma: {} amu; Mb: {} amu; a: {}; p: {} A",
+        max_iterations, E0/Q, x0, err, tolerance, Za, Zb, Ma/AMU, Mb/AMU, a, impact_parameter/ANGSTROM))
 }
 
 /// Gauss-Mehler quadrature.

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -538,7 +538,7 @@ pub fn calculate_binary_collision(particle_1: &particle::Particle, particle_2: &
 /// Mendenhall-Weller scattering integrand.
 fn scattering_integral_mw(x: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //Function for scattering integral - see Mendenhall and Weller, 1991 & 2005
-    return (1. - interactions::phi(x, interaction_potential)/x/reduced_energy - beta*beta/x/x).powf(-0.5);
+    return 1/(1. - interactions::phi(x, interaction_potential)/x/reduced_energy - beta*beta/x/x).sqrt();
 }
 
 /// Gauss-Legendre scattering integrand.
@@ -776,7 +776,7 @@ pub fn mendenhall_weller(Za: f64, Zb: f64, Ma: f64, Mb: f64, E0: f64, impact_par
     let beta: f64 = impact_parameter/a;
 
     //Scattering integral quadrature from Mendenhall and Weller 2005
-    let lambda0 = (0.5 + beta*beta/x0/x0/2. - interactions::dphi(x0,  interaction_potential)/2./reduced_energy).powf(-1./2.);
+    let lambda0 = 1./(0.5 + beta*beta/x0/x0/2. - interactions::dphi(x0,  interaction_potential)/2./reduced_energy).sqrt();
     let alpha = 1./12.*(1. + lambda0 + 5.*(0.4206*scattering_integral_mw(x0/0.9072, beta, reduced_energy,  interaction_potential) + 0.9072*scattering_integral_mw(x0/0.4206, beta, reduced_energy,  interaction_potential)));
     PI*(1. - beta*alpha/x0)
 }

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rand::RngExt;
 
 #[cfg(feature = "cpr_rootfinder")]
 use rcpr::chebyshev::*;
@@ -62,7 +63,7 @@ impl fmt::Display for BinaryCollisionResult {
 }
 
 /// This function takes a single particle, a material, and an options object and runs a binary-collision-approximation trajectory for that particle in that material, producing a final particle list that consists of the original ion and any material particles displaced thereby.
-pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &material::Material<T>, options: &Options) -> Vec<particle::Particle> {
+pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &material::Material<T>, options: &Options, rng: &mut ChaCha8Rng) -> Vec<particle::Particle> {
 
     let mut particles: Vec<particle::Particle> = Vec::new();
     particles.push(particle);
@@ -79,7 +80,7 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
         while !particle_1.stopped & !particle_1.left {
 
             //Choose impact parameters and azimuthal angles for all collisions, and determine mean free path
-            let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material, &options);
+            let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material, &options, rng);
 
             #[cfg(feature = "accelerated_ions")]
             let distance_to_target = if !material.inside(particle_1.pos.x, particle_1.pos.y, particle_1.pos.z) {
@@ -207,7 +208,7 @@ pub fn single_ion_bca<T: Geometry>(particle: particle::Particle, material: &mate
 
 /// For a particle in a material, determine the mean free path and choose the azimuthal angle and impact parameter.
 /// The mean free path can be exponentially distributed (gaseous) or constant (amorphous solid/liquid). Azimuthal angles are chosen uniformly. Impact parameters are chosen for collision partners distributed uniformly on a disk of density-dependent radius.
-pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle::Particle, material: &material::Material<T>, options: &Options) -> Vec<BinaryCollisionGeometry> {
+pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle::Particle, material: &material::Material<T>, options: &Options, rng: &mut ChaCha8Rng) -> Vec<BinaryCollisionGeometry> {
 
     let x = particle_1.pos.x;
     let y = particle_1.pos.y;
@@ -220,7 +221,7 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
 
     //Each weak collision gets its own aziumuthal angle in annuli around collision point
     for k in 0..options.weak_collision_order + 1 {
-        phis_azimuthal.push(2.*PI*rand::random::<f64>());
+        phis_azimuthal.push(2.*PI*rng.random::<f64>());
     }
 
     if options.high_energy_free_flight_paths {
@@ -264,22 +265,22 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
             //Cylindrical geometry
             pmax = mfp/SQRTPI;
             let mut impact_parameter = Vec::with_capacity(1);
-            let random_number = rand::random::<f64>();
+            let random_number = rng.random::<f64>();
             let p = pmax*random_number.sqrt();
             impact_parameter.push(p);
 
             //Atomically rough surface - scatter initial collisions using mfp near interface
             if particle_1.first_step {
-                ffp = mfp*rand::random::<f64>();
+                ffp = mfp*rng.random::<f64>();
                 particle_1.first_step = false;
             }
 
             ffp *= match options.mean_free_path_model {
-                MeanFreePathModel::GASEOUS => -rand::random::<f64>().ln(),
+                MeanFreePathModel::GASEOUS => -rng.random::<f64>().ln(),
                 MeanFreePathModel::LIQUID => 1.0,
                 MeanFreePathModel::THRESHOLD{density} => {
                     if material.geometry.get_densities(x, y, z).iter().sum::<f64>() < density {
-                        -rand::random::<f64>().ln()
+                        -rng.random::<f64>().ln()
                     } else {
                         1.0
                     }
@@ -296,18 +297,18 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
             //And SRIM textbook chapter 7
             //And Eckstein 1991
             let mut impact_parameter = Vec::with_capacity(1);
-            let random_number = rand::random::<f64>();
+            let random_number = rng.random::<f64>();
             let p = pmax*(-random_number.ln()).sqrt();
             impact_parameter.push(p);
 
             //Atomically rough surface - scatter initial collisions using mfp near interface
             if particle_1.first_step {
-                ffp = mfp*rand::random::<f64>();
+                ffp = mfp*rng.random::<f64>();
                 particle_1.first_step = false;
             }
 
             if options.mean_free_path_model == MeanFreePathModel::GASEOUS {
-                ffp *= -rand::random::<f64>().ln();
+                ffp *= -rng.random::<f64>().ln();
             }
 
             binary_collision_geometries.push(BinaryCollisionGeometry::new(phis_azimuthal[0], impact_parameter[0], ffp));
@@ -322,19 +323,19 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
         //Cylindrical geometry
         let mut impact_parameters = Vec::with_capacity(options.weak_collision_order + 1);
         for k in 0..(options.weak_collision_order + 1) {
-            let random_number = rand::random::<f64>();
+            let random_number = rng.random::<f64>();
             let p = pmax*(random_number + k as f64).sqrt();
             impact_parameters.push(p)
         }
 
         //Atomically rough surface - scatter initial collisions
         if particle_1.first_step {
-            mfp *= rand::random::<f64>();
+            mfp *= rng.random::<f64>();
             particle_1.first_step = false;
         }
 
         if options.mean_free_path_model == MeanFreePathModel::GASEOUS {
-            mfp *= -rand::random::<f64>().ln();
+            mfp *= -rng.random::<f64>().ln();
         }
 
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -57,16 +57,14 @@ impl Geometry for Mesh0D {
             "NM" => NM,
             "M" => 1.,
             _ => input.length_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M",
-                        &input.length_unit.as_str()
-                    ).as_str()),
+                .unwrap_or_else(|_| panic!("Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M",
+                        &input.length_unit.as_str())),
         };
 
         let electronic_stopping_correction_factor = input.electronic_stopping_correction_factor;
 
         let densities: Vec<f64> = input.densities.iter().map(|element| element/(length_unit).powi(3)).collect();
-        assert!(densities.len() > 0, "Input Error: density list empty.");
+        assert!(!densities.is_empty(), "Input Error: density list empty.");
 
         let total_density: f64 = densities.iter().sum();
 
@@ -136,7 +134,7 @@ impl Geometry for Mesh1D {
 
         let layer_thicknesses = geometry_input.layer_thicknesses.clone();
         let electronic_stopping_correction_factors = geometry_input.electronic_stopping_correction_factors.clone();
-        assert!(electronic_stopping_correction_factors.len() > 0, "Input Error: Electronic stopping correction factor list empty.");
+        assert!(!electronic_stopping_correction_factors.is_empty(), "Input Error: Electronic stopping correction factor list empty.");
         let n = layer_thicknesses.len();
 
         let mut layers: Vec<Layer1D> =  Vec::with_capacity(n);
@@ -150,9 +148,7 @@ impl Geometry for Mesh1D {
             "NM" => NM,
             "M" => 1.,
             _ => geometry_input.length_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &geometry_input.length_unit.as_str()
-                    ).as_str()),
+                .unwrap_or_else(|_| panic!("Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &geometry_input.length_unit.as_str())),
         };
 
         let densities: Vec<Vec<f64>> = geometry_input.densities
@@ -299,10 +295,8 @@ impl Geometry for HomogeneousMesh2D {
             "NM" => NM,
             "M" => 1.,
             _ => input.length_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M",
-                        &input.length_unit.as_str()
-                    ).as_str()),
+                .unwrap_or_else(|_| panic!("Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M",
+                        &input.length_unit.as_str())),
         };
 
         let boundary_points_converted: Vec<(f64, f64)> = input.points.iter().map(|(x, y)| (x*length_unit, y*length_unit)).collect();
@@ -374,7 +368,7 @@ impl Geometry for HomogeneousMesh2D {
         if let Closest::SinglePoint(p) = self.boundary.closest_point(&point!(x: x, y: y)) {
             (p.x(), p.y(), z)
         } else if let Closest::Intersection(p) = self.boundary.closest_point(&point!(x: x, y: y)) {
-            return (p.x(), p.y(), z)
+            (p.x(), p.y(), z)
         } else {
             panic!("Geometry error: closest point routine failed to find single closest point to ({}, {}, {}).", x, y, z);
         }
@@ -418,7 +412,7 @@ impl Mesh2D {
             }
         }
 
-        return &self.mesh[index];
+        &self.mesh[index]
     }
 }
 
@@ -435,7 +429,7 @@ impl Geometry for Mesh2D {
 
         let simulation_boundary_points = geometry_input.simulation_boundary_points.clone();
         let electronic_stopping_correction_factors = geometry_input.electronic_stopping_correction_factors.clone();
-        assert!(electronic_stopping_correction_factors.len() > 0, "Input Error: Electronic stopping correction factor list empty.");
+        assert!(!electronic_stopping_correction_factors.is_empty(), "Input Error: Electronic stopping correction factor list empty.");
         let n = triangles.len();
 
         let mut cells: Vec<Cell2D> =  Vec::with_capacity(n);
@@ -449,9 +443,7 @@ impl Geometry for Mesh2D {
             "NM" => NM,
             "M" => 1.,
             _ => geometry_input.length_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &geometry_input.length_unit.as_str()
-                    ).as_str()),
+                .unwrap_or_else(|_| panic!("Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M", &geometry_input.length_unit.as_str())),
         };
 
         let densities: Vec<Vec<f64>> = geometry_input.densities
@@ -527,9 +519,9 @@ impl Geometry for Mesh2D {
 
         Mesh2D {
             mesh: cells,
-            boundary: boundary,
-            simulation_boundary: simulation_boundary,
-            energy_barrier_thickness: energy_barrier_thickness,
+            boundary,
+            simulation_boundary,
+            energy_barrier_thickness,
         }
     }
 
@@ -581,7 +573,7 @@ impl Geometry for Mesh2D {
             }
             panic!("Geometry error: point ({}, {}) not found in any cell of the mesh.", x, y);
         } else {
-            return self.nearest_to(x, y, z).electronic_stopping_correction_factor;
+            self.nearest_to(x, y, z).electronic_stopping_correction_factor
         }
     }
 
@@ -595,7 +587,7 @@ impl Geometry for Mesh2D {
             }
             panic!("Geometry error: point ({}, {}) not found in any cell of the mesh.", x, y);
         } else {
-            return self.nearest_to(x, y, z).densities.iter().sum::<f64>();
+            self.nearest_to(x, y, z).densities.iter().sum::<f64>()
         }
     }
 
@@ -609,7 +601,7 @@ impl Geometry for Mesh2D {
             }
             panic!("Geometry error: method inside() is returning true for points outside all cells. Check boundary points.")
         } else {
-            return &self.nearest_to(x, y, z).concentrations;
+            &self.nearest_to(x, y, z).concentrations
         }
     }
 
@@ -758,7 +750,7 @@ impl Triangle2D {
         let b = ((y3 - y1)*(x - x3) + (x1 - x3)*(y - y3)) / ((y2 - y3)*(x1 - x3) + (x3 - x2)*(y1 - y3));
         let c = 1. - a - b;
 
-         (0. <= a) & (a <= 1.) & (0. <= b) & (b <= 1.) & (0. <= c) & (c <= 1.)
+         (0. ..=1.).contains(&a) & (0. ..=1.).contains(&b) & (0. ..=1.).contains(&c)
     }
 
     /// Returns a point (x, y) that is the centroid of the triangle.

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -70,7 +70,7 @@ impl Geometry for Mesh0D {
 
         let total_density: f64 = densities.iter().sum();
 
-        let energy_barrier_thickness = total_density.powf(-1./3.)/SQRTPI*2.;
+        let energy_barrier_thickness = 1./total_density.cbrt()/SQRTPI*2.;
 
         let concentrations: Vec<f64> = densities.iter().map(|&density| density/total_density).collect::<Vec<f64>>();
 
@@ -180,8 +180,8 @@ impl Geometry for Mesh1D {
             layer_top = layer_bottom;
         }
 
-        let top_energy_barrier_thickness = layers[0].densities.iter().sum::<f64>().powf(-1./3.)/SQRTPI*2.;
-        let bottom_energy_barrier_thickness = layers[layers.len() - 1].densities.iter().sum::<f64>().powf(-1./3.)/SQRTPI*2.;
+        let top_energy_barrier_thickness = 1./layers[0].densities.iter().sum::<f64>().cbrt()/SQRTPI*2.;
+        let bottom_energy_barrier_thickness = 1./layers[layers.len() - 1].densities.iter().sum::<f64>().cbrt()/SQRTPI*2.;
 
         Mesh1D {
             layers,
@@ -315,7 +315,7 @@ impl Geometry for HomogeneousMesh2D {
 
         let total_density: f64 = densities.iter().sum();
 
-        let energy_barrier_thickness = total_density.powf(-1./3.)/SQRTPI*2.;
+        let energy_barrier_thickness = 1./total_density.cbrt()/SQRTPI*2.;
 
         let concentrations: Vec<f64> = densities.iter().map(|&density| density/total_density).collect::<Vec<f64>>();
 
@@ -361,7 +361,7 @@ impl Geometry for HomogeneousMesh2D {
             true
         } else {
             if let Closest::SinglePoint(p) = self.boundary.closest_point(&point!(x: x, y: y)) {
-                let distance = ((x - p.x()).powf(2.) +  (y - p.y()).powf(2.)).sqrt();
+                let distance = ((x - p.x()).powi(2) +  (y - p.y()).powi(2)).sqrt();
                 distance < self.energy_barrier_thickness
             } else if let Closest::Intersection(p) = self.boundary.closest_point(&point!(x: x, y: y)) {
                 true

--- a/src/input.rs
+++ b/src/input.rs
@@ -154,6 +154,11 @@ impl InputFile for Input1D {
 }
 
 ///This helper function is a workaround to issue #368 in serde
+fn default_seed() -> u64 {
+    0
+}
+
+///This helper function is a workaround to issue #368 in serde
 fn default_false() -> bool {
     false
 }
@@ -246,6 +251,8 @@ pub struct Options {
     pub track_displacements: bool,
     #[serde(default = "default_false")]
     pub track_energy_losses: bool,
+    #[serde(default = "default_seed")]
+    pub seed: u64
 }
 
 #[cfg(not(feature = "distributions"))]
@@ -269,7 +276,8 @@ impl Options {
             num_chunks: 1,
             use_hdf5: false,
             track_displacements: false,
-            track_energy_losses: false
+            track_energy_losses: false,
+            seed: default_seed(),
         }
     }
 }
@@ -327,6 +335,8 @@ pub struct Options {
     pub x_num: usize,
     pub y_num: usize,
     pub z_num: usize,
+    #[serde(default = "default_seed")]
+    pub seed: u64
 }
 
 #[cfg(feature = "distributions")]
@@ -366,14 +376,13 @@ impl Options {
             x_num: 0,
             y_num: 0,
             z_num: 0,
+            seed: default_seed()
         }
     }
 }
 
 pub fn input<T: Geometry>(input_file: String) -> (Vec<particle::ParticleInput>, material::Material<T>, Options, OutputUnits)
 where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
-
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
 
     //Read input file, convert to string, and open with toml
     let mut input_toml = String::new();
@@ -392,6 +401,9 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
     let mut particle_parameters = (*input.get_particle_parameters()).clone();
     let material_parameters = (*input.get_material_parameters()).clone();
     let mut material: material::Material<T> = material::Material::<T>::new(&material_parameters, input.get_geometry_input());
+
+    // Initialize RNG
+    let mut rng = ChaCha8Rng::seed_from_u64(options.seed);
 
     //Ensure nonsensical threads/chunks options crash on input
     assert!(options.num_threads > 0, "Input error: num_threads must be greater than zero.");

--- a/src/input.rs
+++ b/src/input.rs
@@ -373,6 +373,8 @@ impl Options {
 pub fn input<T: Geometry>(input_file: String) -> (Vec<particle::ParticleInput>, material::Material<T>, Options, OutputUnits)
 where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
 
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+
     //Read input file, convert to string, and open with toml
     let mut input_toml = String::new();
     let mut file = OpenOptions::new()
@@ -558,40 +560,40 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                             m: m*mass_unit,
                             Z: Z,
                             E: match E {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*energy_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*energy_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*energy_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*energy_unit},
                                 Distributions::POINT(E) => E*energy_unit,
                             },
                             Ec: Ec*energy_unit,
                             Es: Es*energy_unit,
                             x: match x {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             y: match y {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(y) => y*length_unit,
                             },
                             z: match z {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(z) => z*length_unit,
                             },
                             ux: match cosx {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(ux) => ux,
                             },
                             uy: match cosy {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(uy) => uy,
                             },
                             uz: match cosz {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(uz) => uz,
                             },
                             interaction_index: interaction_index,
@@ -631,40 +633,40 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                             m: m*mass_unit,
                             Z: Z,
                             E: match E {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*energy_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*energy_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*energy_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*energy_unit},
                                 Distributions::POINT(x) => x*energy_unit,
                             },
                             Ec: Ec*energy_unit,
                             Es: Es*energy_unit,
                             x: match x {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             y: match y {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             z: match z {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             ux: match cosx {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit
                             },
                             uy: match cosy {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             uz: match cosz {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             interaction_index: interaction_index,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,6 @@
 use super::*;
-use rand_distr::{Normal, Distribution, Uniform};
+use rand::distr::{Uniform};
+use rand_distr::{Normal, Distribution};
 
 pub trait InputFile: GeometryInput {
     fn new(string: &str) -> Self;
@@ -557,40 +558,40 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                             m: m*mass_unit,
                             Z: Z,
                             E: match E {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*energy_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*energy_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*energy_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*energy_unit},
                                 Distributions::POINT(E) => E*energy_unit,
                             },
                             Ec: Ec*energy_unit,
                             Es: Es*energy_unit,
                             x: match x {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             y: match y {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(y) => y*length_unit,
                             },
                             z: match z {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(z) => z*length_unit,
                             },
                             ux: match cosx {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(ux) => ux,
                             },
                             uy: match cosy {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(uy) => uy,
                             },
                             uz: match cosz {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(uz) => uz,
                             },
                             interaction_index: interaction_index,
@@ -630,40 +631,40 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                             m: m*mass_unit,
                             Z: Z,
                             E: match E {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*energy_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*energy_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*energy_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*energy_unit},
                                 Distributions::POINT(x) => x*energy_unit,
                             },
                             Ec: Ec*energy_unit,
                             Es: Es*energy_unit,
                             x: match x {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             y: match y {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             z: match z {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             ux: match cosx {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(x) => x*length_unit
                             },
                             uy: match cosy {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             uz: match cosz {
-                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::thread_rng())*length_unit},
-                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::from(min..max);  uniform.sample(&mut rand::thread_rng())*length_unit},
+                                Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rand::rng())*length_unit},
+                                Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rand::rng())*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
                             interaction_index: interaction_index,

--- a/src/input.rs
+++ b/src/input.rs
@@ -154,7 +154,7 @@ impl InputFile for Input1D {
 }
 
 ///This helper function is a workaround to issue #368 in serde
-fn default_seed() -> u64 {
+fn default_seed() -> i32 {
     0
 }
 
@@ -252,7 +252,7 @@ pub struct Options {
     #[serde(default = "default_false")]
     pub track_energy_losses: bool,
     #[serde(default = "default_seed")]
-    pub seed: u64
+    pub seed: i32
 }
 
 #[cfg(not(feature = "distributions"))]
@@ -261,7 +261,7 @@ impl Options {
         Options {
             name: "default".to_string(),
             track_trajectories: false,
-            track_recoils: track_recoils,
+            track_recoils,
             track_recoil_trajectories: false,
             write_buffer_size: default_buffer_size(),
             weak_collision_order: zero_usize(),
@@ -336,7 +336,7 @@ pub struct Options {
     pub y_num: usize,
     pub z_num: usize,
     #[serde(default = "default_seed")]
-    pub seed: u64
+    pub seed: i32
 }
 
 #[cfg(feature = "distributions")]
@@ -391,7 +391,7 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
         .write(false)
         .create(false)
         .open(&input_file)
-        .expect(format!("Input errror: could not open input file {}.", &input_file).as_str());
+        .unwrap_or_else(|_| panic!("Input errror: could not open input file {}.", &input_file));
     file.read_to_string(&mut input_toml).context("Could not convert TOML file to string.").unwrap();
 
     let input: <T as Geometry>::InputFileFormat = InputFile::new(&input_toml);
@@ -403,7 +403,11 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
     let mut material: material::Material<T> = material::Material::<T>::new(&material_parameters, input.get_geometry_input());
 
     // Initialize RNG
-    let mut rng = ChaCha8Rng::seed_from_u64(options.seed);
+    let mut rng = if options.seed < 0 {
+            ChaCha8Rng::seed_from_u64(rand::random())
+    } else {
+            ChaCha8Rng::seed_from_u64(u64::try_from(options.seed).expect("Value Error: seed not u64."))
+    };
 
     //Ensure nonsensical threads/chunks options crash on input
     assert!(options.num_threads > 0, "Input error: num_threads must be greater than zero.");
@@ -510,10 +514,8 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
         "NM" => NM,
         "M" => 1.,
         _ => particle_parameters.length_unit.parse()
-            .expect(format!(
-                    "Input errror: could nor parse length unit {}. Use a valid float or one of
-                    ANGSTROM, NM, MICRON, CM, MM, M", &particle_parameters.length_unit.as_str()
-                ).as_str()),
+            .unwrap_or_else(|_| panic!("Input errror: could nor parse length unit {}. Use a valid float or one of
+                    ANGSTROM, NM, MICRON, CM, MM, M", &particle_parameters.length_unit.as_str())),
     };
 
     let energy_unit: f64 = match particle_parameters.energy_unit.as_str() {
@@ -522,18 +524,14 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
         "KEV" => EV*1E3,
         "MEV" => EV*1E6,
         _ => particle_parameters.energy_unit.parse()
-            .expect(format!(
-                    "Input errror: could nor parse energy unit {}. Use a valid float or one of EV, J, KEV, MEV", &particle_parameters.energy_unit.as_str()
-                ).as_str()),
+            .unwrap_or_else(|_| panic!("Input errror: could nor parse energy unit {}. Use a valid float or one of EV, J, KEV, MEV", &particle_parameters.energy_unit.as_str())),
     };
 
     let mass_unit: f64 = match particle_parameters.mass_unit.as_str() {
         "AMU" => AMU,
         "KG" => 1.0,
         _ => particle_parameters.mass_unit.parse()
-            .expect(format!(
-                    "Input errror: could nor parse mass unit {}. Use a valid float or one of AMU, KG", &particle_parameters.mass_unit.as_str()
-                ).as_str()),
+            .unwrap_or_else(|_| panic!("Input errror: could nor parse mass unit {}. Use a valid float or one of AMU, KG", &particle_parameters.mass_unit.as_str())),
     };
 
     //HDF5
@@ -643,7 +641,7 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                     particle_input.push(
                         particle::ParticleInput{
                             m: m*mass_unit,
-                            Z: Z,
+                            Z,
                             E: match E {
                                 Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*energy_unit},
                                 Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*energy_unit},
@@ -681,7 +679,7 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                                 Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
                                 Distributions::POINT(x) => x*length_unit,
                             },
-                            interaction_index: interaction_index,
+                            interaction_index,
                             tag: 0,
                             weight: 1.0,
                         }

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -22,7 +22,7 @@ fn smootherstep(x: f64, k: f64, x0: f64) -> f64 {
         1.
     } else {
         let x1 = x_transformed - x0_transformed + 0.5;
-        return x1 * x1 * x1 * (x1 * (6. * x1 - 15.) + 10.);
+        x1 * x1 * x1 * (x1 * (6. * x1 - 15.) + 10.)
     }
 }
 
@@ -72,25 +72,25 @@ pub fn energy_threshold_single_root(interaction_potential: InteractionPotential)
 /// Distance of closest approach function for screened coulomb potentials.
 fn doca_function(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //Nonlinear equation to determine distance of closest approach
-    return x0 - interactions::phi(x0, interaction_potential)/reduced_energy - beta*beta/x0;
+    x0 - interactions::phi(x0, interaction_potential)/reduced_energy - beta*beta/x0
 }
 
 /// First derivative w.r.t. `r` of the distance of closest approach function for screened coulomb potentials.
 fn diff_doca_function(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //First differential of distance of closest approach function for N-R solver
-    return beta*beta/x0/x0 - interactions::dphi(x0, interaction_potential)/reduced_energy + 1.
+    beta*beta/x0/x0 - interactions::dphi(x0, interaction_potential)/reduced_energy + 1.
 }
 
 /// Singularity-free version of the screened-coulomb distance of closest approach function.
 fn doca_function_transformed(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //Singularity free version of doca function
-    return x0*x0 - x0*interactions::phi(x0, interaction_potential)/reduced_energy - beta*beta;
+    x0*x0 - x0*interactions::phi(x0, interaction_potential)/reduced_energy - beta*beta
 }
 
 /// First derivative w.r.t. `r` of the singularity-free version of the screened-coulomb distance of closest approach function.
 fn diff_doca_function_transformed(x0: f64, beta: f64, reduced_energy: f64, interaction_potential: InteractionPotential) -> f64 {
     //First differential of distance of closest approach function for N-R solver
-    return 2.*x0 - interactions::phi(x0, interaction_potential)/reduced_energy
+    2.*x0 - interactions::phi(x0, interaction_potential)/reduced_energy
 }
 
 /// Distance of closest approach function. The outermost root of this function is the distance of closest approach, or classical turning point, which is the lower bound to the scattering integral.
@@ -240,7 +240,7 @@ pub fn screened_coulomb(r: f64, a: f64, Za: f64, Zb: f64, interaction_potential:
 
 /// Coulombic interaction potential.
 pub fn coulomb(r: f64, Za: f64, Zb: f64) -> f64 {
-    return Za*Zb*Q*Q/4./PI/EPS0/r;
+    Za*Zb*Q*Q/4./PI/EPS0/r
 }
 
 /// Screening functions for screened-coulomb interaction potentials.
@@ -414,14 +414,12 @@ pub fn tungsten_tungsten_cubic_spline(r: f64) -> f64 {
 
     } else if x <= x2 {
 
-        let a = vec![
-            1.389653276380862E4,
+        let a = [1.389653276380862E4,
             -3.596912431628216E4,
             3.739206756369099E4,
             -1.933748081656593E4,
             0.495516793802426E4,
-            -0.050264585985867E4
-        ];
+            -0.050264585985867E4];
 
         (a[0] + a[1]*x + a[2]*x.powi(2) + a[3]*x.powi(3) + a[4]*x.powi(4) + a[5]*x.powi(5))*EV
 
@@ -431,7 +429,7 @@ pub fn tungsten_tungsten_cubic_spline(r: f64) -> f64 {
             -0.1036435865158945,
             -0.2912948318493851,
             -2.096765499656263,
-            19.16045452701010,
+            19.160_454_527_010_1,
             -41.01619862085917,
             46.05205617244703,
             26.42203930654883,
@@ -440,15 +438,15 @@ pub fn tungsten_tungsten_cubic_spline(r: f64) -> f64 {
         ];
 
         let delta = vec![
-            4.268900000000000,
-            3.985680000000000,
-            3.702460000000000,
-            3.419240000000000,
-            3.136020000000000,
-            2.852800000000000,
-            2.741100000000000,
-            2.604045000000000,
-            2.466990000000000,
+            4.268_9,
+            3.985_68,
+            3.702_46,
+            3.419_24,
+            3.136_02,
+            2.852_8,
+            2.741_1,
+            2.604_045,
+            2.466_99,
         ];
 
         a.iter().zip(delta).map(|(&a_i, delta_i)| EV*a_i*(delta_i - x).powi(3)*heaviside(delta_i - x)).sum::<f64>()

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -166,15 +166,12 @@ pub fn scaling_function(r: f64, a: f64, interaction_potential: InteractionPotent
             1./(1. + (r/a).powi(2))
         },
         InteractionPotential::LENNARD_JONES_12_6{sigma, ..} => {
-            let n = 11.;
-            1./(1. + (r/sigma).powf(n))
+            1./(1. + (r/sigma).powi(11))
         },
         InteractionPotential::LENNARD_JONES_65_6{sigma, ..} => {
-            let n = 6.;
-            1./(1. + (r/sigma).powf(n))
+            1./(1. + (r/sigma).powi(6))
         },
         InteractionPotential::FOUR_EIGHT{alpha, beta} => {
-            let n = 8.;
             1./(1. + r.powi(8)/beta)
         }
         InteractionPotential::MORSE{D, alpha, r0} => {
@@ -294,15 +291,14 @@ pub fn polynomial_coefficients(relative_energy: f64, impact_parameter: f64, inte
             let epsilon_ev = epsilon/EV;
             let sigma_angstroms = sigma/ANGSTROM;
             let relative_energy_ev = relative_energy/EV;
-            //vec![1., 0., -impact_parameter.powi(2), 0., 0., 0., 4.*epsilon_ev*sigma.powf(6.)/relative_energy_ev, 0., 0., 0., 0., 0., -4.*epsilon_ev*sigma.powf(12.)/relative_energy_ev]
-            vec![1.0, -impact_parameter.powi(2), 0.0, 4.*epsilon_ev*sigma.powf(6.)/relative_energy_ev, 0.0, 0.0, -4.*epsilon_ev*sigma.powf(12.)/relative_energy_ev]
+            vec![1.0, -impact_parameter.powi(2), 0.0, 4.*epsilon_ev*sigma.powi(6)/relative_energy_ev, 0.0, 0.0, -4.*epsilon_ev*sigma.powi(12)/relative_energy_ev]
         },
         InteractionPotential::LENNARD_JONES_65_6{sigma, epsilon} => {
             let impact_parameter_angstroms = impact_parameter/ANGSTROM;
             let epsilon_ev = epsilon/EV;
             let sigma_angstroms = sigma/ANGSTROM;
             let relative_energy_ev = relative_energy/EV;
-            vec![1., 0., 0., 0., -impact_parameter.powi(2), 0., 0., 0., 0., 0., 0., 0., 4.*epsilon_ev*sigma.powf(6.)/relative_energy_ev, -4.*epsilon_ev*sigma.powf(6.5)/relative_energy_ev]
+            vec![1., 0., 0., 0., -impact_parameter.powi(2), 0., 0., 0., 0., 0., 0., 0., 4.*epsilon_ev*sigma.powi(6)/relative_energy_ev, -4.*epsilon_ev*sigma.powf(6.5)/relative_energy_ev]
         },
         InteractionPotential::FOUR_EIGHT{alpha, beta} => {
             //Note: I've transformed to angstroms here to help the rootfinder with numerical issues.
@@ -343,12 +339,12 @@ pub fn four_eight(r: f64, alpha: f64, beta: f64) -> f64 {
 
 /// Lennard-Jones 12-6
 pub fn lennard_jones(r: f64, sigma: f64, epsilon: f64) -> f64 {
-    4.*epsilon*((sigma/r).powf(12.) - (sigma/r).powf(6.))
+    4.*epsilon*((sigma/r).powi(12) - (sigma/r).powi(6))
 }
 
 /// Lennard-Jones 6.5-6
 pub fn lennard_jones_65_6(r: f64, sigma: f64, epsilon: f64) -> f64 {
-    4.*epsilon*((sigma/r).powf(6.5) - (sigma/r).powf(6.))
+    4.*epsilon*((sigma/r).powf(6.5) - (sigma/r).powi(6))
 }
 
 /// Morse potential
@@ -366,7 +362,7 @@ pub fn doca_four_eight(r: f64, impact_parameter: f64, relative_energy: f64, alph
     let a = alpha.powf(1./4.);
     let b = beta.powf(1./8.);
     let b4 = beta.sqrt();
-    (r/b).powf(8.) - (-(a*r/b/b) + 1.)/relative_energy - (impact_parameter*r.powf(3.)/b4)
+    (r/b).powi(8) - (-(a*r/b/b) + 1.)/relative_energy - (impact_parameter*r.powi(3)/b4)
 }
 
 /// Distance of closest approach function for Morse potential.
@@ -391,17 +387,17 @@ pub fn doca_lennard_jones_65_6(r: f64, p: f64, relative_energy: f64, sigma: f64,
 
 /// Distance of closest approach function for LJ 12-6 potential.
 pub fn doca_lennard_jones(r: f64, p: f64, relative_energy: f64, sigma: f64, epsilon: f64) -> f64 {
-    (r/sigma).powf(12.) - 4.*epsilon/relative_energy*(1. - (r/sigma).powf(6.)) - p.powi(2)*r.powf(10.)/sigma.powf(12.)
+    (r/sigma).powi(12) - 4.*epsilon/relative_energy*(1. - (r/sigma).powi(6)) - p.powi(2)*r.powi(10)/sigma.powi(12)
 }
 
 /// First derivative w.r.t. `r` of the distance of closest approach function for LJ 12-6 potential.
 pub fn diff_doca_lennard_jones(r: f64, p: f64, relative_energy: f64, sigma: f64, epsilon: f64) -> f64 {
-    12.*(r/sigma).powf(11.)/sigma + 4.*epsilon/relative_energy*6.*(r/sigma).powf(5.)/sigma - 10.*p.powi(2)*r.powf(9.)/sigma.powf(12.)
+    12.*(r/sigma).powi(11)/sigma + 4.*epsilon/relative_energy*6.*(r/sigma).powi(5)/sigma - 10.*p.powi(2)*r.powi(9)/sigma.powi(12)
 }
 
 /// First derivative w.r.t. `r` of the distance of closest approach function for LJ 6.5-6 potential.
 pub fn diff_doca_lennard_jones_65_6(r: f64, p: f64, relative_energy: f64, sigma: f64, epsilon: f64) -> f64 {
-    6.5*(r/sigma).powf(5.5)/sigma + 4.*epsilon/relative_energy*0.5*(sigma*r).powf(-0.5) - (p/sigma).powi(2)*4.5*(r/sigma).powf(3.5)/sigma
+    6.5*(r/sigma).powf(5.5)/sigma + 4.*epsilon/relative_energy*0.5/(sigma*r).sqrt() - (p/sigma).powi(2)*4.5*(r/sigma).powf(3.5)/sigma
 }
 
 /// W-W cublic spline potential from Bjorkas et al.
@@ -427,7 +423,7 @@ pub fn tungsten_tungsten_cubic_spline(r: f64) -> f64 {
             -0.050264585985867E4
         ];
 
-        (a[0] + a[1]*x + a[2]*x.powi(2) + a[3]*x.powi(3) + a[4]*x.powf(4.) + a[5]*x.powf(5.))*EV
+        (a[0] + a[1]*x + a[2]*x.powi(2) + a[3]*x.powi(3) + a[4]*x.powi(4) + a[5]*x.powi(5))*EV
 
     } else {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,7 +593,14 @@ pub extern "C" fn compound_bca_list_c(input: InputCompoundBCA) -> OutputBCA {
 
     let velocities = unsafe { slice::from_raw_parts(input.velocities, input.len) };
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
     for velocity in velocities {
 
         let vx = velocity[0];
@@ -730,7 +737,14 @@ pub extern "C" fn compound_bca_list_fortran(num_incident_ions: &mut c_int, track
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
     for (((((((E1_, ux_), uy_), uz_), Z1_), Ec1_), Es1_), m1_) in E1.iter().zip(ux).zip(uy).zip(uz).zip(Z1).zip(Ec1).zip(Es1).zip(m1) {
 
         let p = particle::Particle {
@@ -876,7 +890,14 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
     };
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
     for (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_) in izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1) {
 
@@ -1003,6 +1024,13 @@ pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f6
 
     let mut finished_particles: Vec<particle::Particle> = Vec::new();
 
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+
     let incident_particles: Vec<particle::Particle> = izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1)
         .enumerate()
         .map(|(index, (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_))| {
@@ -1021,12 +1049,11 @@ pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f6
             p
         }).collect();
 
-        static SEED: u64 = 0;
         finished_particles.par_extend(
             incident_particles.into_par_iter()
             .enumerate()
             .map_init(
-                || ChaCha8Rng::seed_from_u64(SEED),
+                || ChaCha8Rng::seed_from_u64(seed),
                 | rng, (particle_index, incident_particle)| {
                     rng.set_stream(particle_index as u64);
                     bca::single_ion_bca(incident_particle, &m, &options, rng)
@@ -1760,10 +1787,16 @@ pub fn sputtering_yield(ion: &PyDict, target: &PyDict, energy: f64, angle: f64, 
 
     let num_sputtered = Mutex::new(0);
 
-    static SEED: u64 = 0;
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+
     (0..num_samples as u64).into_par_iter()
     .for_each_init(
-        || ChaCha8Rng::seed_from_u64(SEED), |rng, index| {
+        || ChaCha8Rng::seed_from_u64(seed), |rng, index| {
 
         let p = particle::Particle::default_incident(
             m1,
@@ -1860,8 +1893,8 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
     let energy_reflected = Mutex::new(0.0);
     let residue = Mutex::new(0.0);
 
-
     let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
         Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
         Err(env::VarError::NotPresent) => 0_u64,
         Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
@@ -1870,7 +1903,6 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
     (0..num_samples as u64).into_par_iter()
     .for_each_init(
         || ChaCha8Rng::seed_from_u64(seed), |rng, index| {
-
         let p = particle::Particle::default_incident(
             m1,
             Z1,
@@ -1981,12 +2013,16 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
     let energy_reflected = Mutex::new(0.0);
     let residue = Mutex::new(0.0);
 
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
 
-
-    static SEED: u64 = 0;
     (0..num_samples as u64).into_par_iter()
     .for_each_init(
-        || ChaCha8Rng::seed_from_u64(SEED), |rng, index| {
+        || ChaCha8Rng::seed_from_u64(seed), |rng, index| {
 
         let p = particle::Particle::default_incident(
             m1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,7 +876,6 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
 
-    let mut index: usize = 0;
     for (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_) in izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1) {
 
         let mut energy_out;
@@ -921,7 +920,6 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
                 );
             }
         }
-        index += 1;
     }
     (total_output, incident)
 }
@@ -1027,9 +1025,9 @@ pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f6
             .enumerate()
             .map_init(
                 || ChaCha8Rng::seed_from_u64(SEED),
-                | rng, (particle_index, particle_input)| {
+                | rng, (particle_index, incident_particle)| {
                     rng.set_stream(particle_index as u64);
-                    bca::single_ion_bca(particle, &m, &options, &mut rng)
+                    bca::single_ion_bca(incident_particle, &m, &options, rng)
                 } 
             )
             .flatten()
@@ -1039,7 +1037,7 @@ pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f6
             if (particle.left) | (particle.incident) {
                 incident.push(particle.incident);
                 incident_index.push(particle.tag as usize);
-                let mut energy_out;
+                let energy_out;
                 if particle.stopped {
                     energy_out = 0.;
                 } else {
@@ -1235,8 +1233,6 @@ pub fn compound_bca_list_1D_py(ux: Vec<f64>, uy: Vec<f64>, uz: Vec<f64>, energie
 
     let x = -m.geometry.top_energy_barrier_thickness/2.;
 
-    let mut index: usize = 0;
-
     for (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_) in izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1) {();
 
         let mut energy_out;
@@ -1282,7 +1278,6 @@ pub fn compound_bca_list_1D_py(ux: Vec<f64>, uy: Vec<f64>, uz: Vec<f64>, energie
                 );
             }
         }
-        index += 1;
     }
     (total_output, incident, stopped)
 }
@@ -1544,7 +1539,7 @@ pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mu
     *ux = incident.x;
     *uy = incident.y;
     *uz = incident.z;
-    let mag = (ux*ux + uy*uy + uz*uz).sqrt();
+    let mag = (ux.powi(2) + uy.powi(2) + uz.powi(2)).sqrt();
 
     *ux /= mag;
     *uy /= mag;
@@ -1781,7 +1776,7 @@ pub fn sputtering_yield(ion: &PyDict, target: &PyDict, energy: f64, angle: f64, 
         );
         
         rng.set_stream(index);
-        let output = bca::single_ion_bca(p, &m, &options);
+        let output = bca::single_ion_bca(p, &m, &options, rng);
 
         for particle in output {
             if particle.E > 0.0 && particle.dir.x < 0.0 && particle.left && (!particle.incident) {
@@ -1880,7 +1875,7 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
         );
         
         rng.set_stream(index);
-        let output = bca::single_ion_bca(p, &m, &options);
+        let output = bca::single_ion_bca(p, &m, &options, rng);
 
         for particle in output {
             if particle.E > 0.0 && particle.dir.x < 0.0 && particle.left && particle.incident {
@@ -1985,7 +1980,7 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
         );
         
         rng.set_stream(index);
-        let output = bca::single_ion_bca(p, &m, &options);
+        let output = bca::single_ion_bca(p, &m, &options, rng);
 
         for particle in output {
             if particle.E > 0.0 && particle.dir.x < 0.0 && particle.left && particle.incident {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1888,6 +1888,7 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
 
                 let mut residue_part;
 
+                // Use Moller-Knuth TwoSum to preserve deterministic fp reduce
                 (*energy_reflected, residue_part) = moller_knuth_two_sum(*energy_reflected, particle.E);
 
                 let mut residue = residue.lock().unwrap();
@@ -2002,6 +2003,7 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
 
                 let mut residue_part;
 
+                // Use Moller-Knuth TwoSum to preserve deterministic fp reduce
                 (*energy_reflected, residue_part) = moller_knuth_two_sum(*energy_reflected, particle.E);
 
                 let mut residue = residue.lock().unwrap();
@@ -2017,7 +2019,17 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
     (num_reflected as f64 / num_samples as f64, (energy_reflected + residue) / EV / energy / num_samples as f64)
 }
 
+/// Moller-Knuth TwoSum Floating-Point Adder with Residual (FPAR)
+/// This function allows one to use the identity: 
+/// Given two floating point numbers a, b;
+/// And the sum s = IEEE754RoundToNearest(a + b);
+/// And the residual from floating point error r = (a + b) - s;
+/// The following is invariant: s + r = a + b
+/// citation: Accurate Parallel Floating-Point Accumulation
+/// E. Kadric et al., IEEE Transactions on Computers 65 11
+/// doi: 10.1109/TC.2016.2532874
 fn moller_knuth_two_sum(a: f64, b: f64) -> (f64, f64) {
+    
     let s = a + b;
     let b_prime = s - a;
     let a_prime = s - b_prime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2086,8 +2086,8 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
 /// citation: Accurate Parallel Floating-Point Accumulation
 /// E. Kadric et al., IEEE Transactions on Computers 65 11
 /// doi: 10.1109/TC.2016.2532874
+#[cfg(feature = "python")]
 fn moller_knuth_two_sum(a: f64, b: f64) -> (f64, f64) {
-    
     let s = a + b;
     let b_prime = s - a;
     let a_prime = s - b_prime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,14 @@ pub extern "C" fn simple_bca_list_c(input: InputSimpleBCA) -> OutputBCA {
 
     let velocities = unsafe { slice::from_raw_parts(input.velocities, input.len) };
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
     for velocity in velocities {
 
         let vx = velocity[0];
@@ -1262,7 +1269,14 @@ pub fn compound_bca_list_1D_py(ux: Vec<f64>, uy: Vec<f64>, uz: Vec<f64>, energie
 
     let x = -m.geometry.top_energy_barrier_thickness/2.;
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) if seed == "-1" => rand::random(),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
     for (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_) in izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1) {();
 
         let mut energy_out;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -875,6 +875,7 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
     };
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
 
     for (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_) in izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1) {
 
@@ -892,7 +893,7 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
             uz_
         );
 
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        
         let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
@@ -1418,7 +1419,7 @@ pub fn simple_bca(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64, E1: f64, Z1
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
     let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     output.iter().filter(|particle| (particle.incident) | (particle.left)).map(|particle|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1137,7 +1137,7 @@ pub fn reflect_single_ion_py(ion: &PyDict, target: &PyDict, vx: f64, vy: f64, vz
         uz
     );
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
     let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     let reflected_energy = output[0].E; //Joules
@@ -1235,6 +1235,7 @@ pub fn compound_bca_list_1D_py(ux: Vec<f64>, uy: Vec<f64>, uz: Vec<f64>, energie
 
     let x = -m.geometry.top_energy_barrier_thickness/2.;
 
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
     for (energy, ux_, uy_, uz_, Z1_, Ec1_, Es1_, m1_) in izip!(energies, ux, uy, uz, Z1, Ec1, Es1, m1) {();
 
         let mut energy_out;
@@ -1251,7 +1252,6 @@ pub fn compound_bca_list_1D_py(ux: Vec<f64>, uy: Vec<f64>, uz: Vec<f64>, energie
             uz_
         );
 
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
         let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
@@ -1497,7 +1497,7 @@ pub fn simple_compound_bca(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64, E1
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
     let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     output.iter().filter(|particle| (particle.incident) | (particle.left)).map(|particle|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1858,6 +1858,7 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
 
     let num_reflected = Mutex::new(0);
     let energy_reflected = Mutex::new(0.0);
+    let residue = Mutex::new(0.0);
 
     static SEED: u64 = 0;
     (0..num_samples as u64).into_par_iter()
@@ -1884,14 +1885,22 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
                 let mut num_reflected = num_reflected.lock().unwrap();
                 *num_reflected += 1;
                 let mut energy_reflected = energy_reflected.lock().unwrap();
-                *energy_reflected += particle.E;
+
+                let mut residue_part;
+
+                (*energy_reflected, residue_part) = moller_knuth_two_sum(*energy_reflected, particle.E);
+
+                let mut residue = residue.lock().unwrap();
+                *residue = *residue + residue_part;
+
             }
         }
     });
     let num_reflected = *num_reflected.lock().unwrap();
     let energy_reflected = *energy_reflected.lock().unwrap();
+    let residue = *residue.lock().unwrap();
 
-    (num_reflected as f64 / num_samples as f64, energy_reflected / EV / energy / num_samples as f64)
+    (num_reflected as f64 / num_samples as f64, (energy_reflected + residue) / EV / energy / num_samples as f64)
 }
 
 #[cfg(feature = "python")]
@@ -1963,6 +1972,7 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
 
     let num_reflected = Mutex::new(0);
     let energy_reflected = Mutex::new(0.0);
+    let residue = Mutex::new(0.0);
 
     static SEED: u64 = 0;
     (0..num_samples as u64).into_par_iter()
@@ -1989,12 +1999,30 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
                 let mut num_reflected = num_reflected.lock().unwrap();
                 *num_reflected += 1;
                 let mut energy_reflected = energy_reflected.lock().unwrap();
-                *energy_reflected += particle.E;
+
+                let mut residue_part;
+
+                (*energy_reflected, residue_part) = moller_knuth_two_sum(*energy_reflected, particle.E);
+
+                let mut residue = residue.lock().unwrap();
+                *residue = *residue + residue_part;
+
             }
         }
     });
     let num_reflected = *num_reflected.lock().unwrap();
     let energy_reflected = *energy_reflected.lock().unwrap();
+    let residue = *residue.lock().unwrap();
 
-    (num_reflected as f64 / num_samples as f64, energy_reflected / EV / energy / num_samples as f64)
+    (num_reflected as f64 / num_samples as f64, (energy_reflected + residue) / EV / energy / num_samples as f64)
+}
+
+fn moller_knuth_two_sum(a: f64, b: f64) -> (f64, f64) {
+    let s = a + b;
+    let b_prime = s - a;
+    let a_prime = s - b_prime;
+    let delta_b = b - b_prime;
+    let delta_a = a - a_prime;
+    let r = delta_a + delta_b;
+    (s, r)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2029,7 +2029,7 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
 
     let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
         Ok(seed) if seed == "-1" => rand::random(),
-        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64 or not -1."),
         Err(env::VarError::NotPresent) => 0_u64,
         Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-use std::{fmt};
+use std::{fmt, env};
 use std::mem::discriminant;
 
 use std::alloc::{dealloc, Layout};
@@ -1860,10 +1860,16 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
     let energy_reflected = Mutex::new(0.0);
     let residue = Mutex::new(0.0);
 
-    static SEED: u64 = 0;
+
+    let seed: u64 = match env::var("LIBRUSTBCA_SEED") {
+        Ok(seed) => seed.parse().expect("Value Error: LIBRUSTBCA_SEED not parsable as u64."),
+        Err(env::VarError::NotPresent) => 0_u64,
+        Err(env::VarError::NotUnicode(_)) => panic!("Value Error: LIBRUSTBCA_SEED not valid unicode.")
+    };
+
     (0..num_samples as u64).into_par_iter()
     .for_each_init(
-        || ChaCha8Rng::seed_from_u64(SEED), |rng, index| {
+        || ChaCha8Rng::seed_from_u64(seed), |rng, index| {
 
         let p = particle::Particle::default_incident(
             m1,
@@ -1886,7 +1892,7 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
                 *num_reflected += 1;
                 let mut energy_reflected = energy_reflected.lock().unwrap();
 
-                let mut residue_part;
+                let residue_part;
 
                 // Use Moller-Knuth TwoSum to preserve deterministic fp reduce
                 (*energy_reflected, residue_part) = moller_knuth_two_sum(*energy_reflected, particle.E);
@@ -1975,6 +1981,8 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
     let energy_reflected = Mutex::new(0.0);
     let residue = Mutex::new(0.0);
 
+
+
     static SEED: u64 = 0;
     (0..num_samples as u64).into_par_iter()
     .for_each_init(
@@ -2001,7 +2009,7 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
                 *num_reflected += 1;
                 let mut energy_reflected = energy_reflected.lock().unwrap();
 
-                let mut residue_part;
+                let residue_part;
 
                 // Use Moller-Knuth TwoSum to preserve deterministic fp reduce
                 (*energy_reflected, residue_part) = moller_knuth_two_sum(*energy_reflected, particle.E);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,9 @@ use std::sync::Mutex;
 //itertools
 use itertools::{izip};
 
+//RNG
+use rand::{SeedableRng, rngs::ChaCha8Rng};
+
 //Math
 use std::f64::consts::FRAC_2_SQRT_PI;
 use std::f64::consts::PI;
@@ -306,7 +309,8 @@ pub extern "C" fn compound_tagged_bca_list_c(input: InputTaggedBCA) -> OutputTag
             tracked_vector: Vector::new(positions[index][0], positions[index][1], positions[index][2]),
         };
 
-        let output = bca::single_ion_bca(p, &m, &options);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
 
@@ -423,7 +427,8 @@ pub extern "C" fn reflect_single_ion_c(num_species_target: &mut c_int, ux: &mut 
         tracked_vector: Vector::new(0.0, 0.0, 0.0),
     };
 
-    let output = bca::single_ion_bca(p, &m, &options);
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     *ux = output[0].dir.x;
     *uy = output[0].dir.y;
@@ -513,8 +518,8 @@ pub extern "C" fn simple_bca_list_c(input: InputSimpleBCA) -> OutputBCA {
             tracked_vector: Vector::new(0.0, 0.0, 0.0),
         };
 
-
-        let output = bca::single_ion_bca(p, &m, &options);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
 
@@ -631,8 +636,8 @@ pub extern "C" fn compound_bca_list_c(input: InputCompoundBCA) -> OutputBCA {
             tracked_vector: Vector::new(0.0, 0.0, 0.0),
         };
 
-
-        let output = bca::single_ion_bca(p, &m, &options);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
 
@@ -756,7 +761,8 @@ pub extern "C" fn compound_bca_list_fortran(num_incident_ions: &mut c_int, track
             tracked_vector: Vector::new(0.0, 0.0, 0.0)
         };
 
-        let output = bca::single_ion_bca(p, &m, &options);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
 
@@ -887,7 +893,8 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
             uz_
         );
 
-        let output = bca::single_ion_bca(p, &m, &options);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
             if (particle.left) | (particle.incident) {
@@ -1014,9 +1021,17 @@ pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f6
             p
         }).collect();
 
+        static SEED: u64 = 0;
         finished_particles.par_extend(
             incident_particles.into_par_iter()
-            .map(|particle| bca::single_ion_bca(particle, &m, &options))
+            .enumerate()
+            .map_init(
+                || ChaCha8Rng::seed_from_u64(SEED),
+                | rng, (particle_index, particle_input)| {
+                    rng.set_stream(particle_index as u64);
+                    bca::single_ion_bca(particle, &m, &options, &mut rng)
+                } 
+            )
             .flatten()
         );
 
@@ -1122,7 +1137,8 @@ pub fn reflect_single_ion_py(ion: &PyDict, target: &PyDict, vx: f64, vy: f64, vz
         uz
     );
 
-    let output = bca::single_ion_bca(p, &m, &options);
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     let reflected_energy = output[0].E; //Joules
 
@@ -1237,7 +1253,8 @@ pub fn compound_bca_list_1D_py(ux: Vec<f64>, uy: Vec<f64>, uz: Vec<f64>, energie
             uz_
         );
 
-        let output = bca::single_ion_bca(p, &m, &options);
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
             if (particle.left) | (particle.incident) {
@@ -1406,7 +1423,8 @@ pub fn simple_bca(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64, E1: f64, Z1
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
 
-    let output = bca::single_ion_bca(p, &m, &options);
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     output.iter().filter(|particle| (particle.incident) | (particle.left)).map(|particle|
         [
@@ -1482,7 +1500,8 @@ pub fn simple_compound_bca(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64, E1
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
 
-    let output = bca::single_ion_bca(p, &m, &options);
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     output.iter().filter(|particle| (particle.incident) | (particle.left)).map(|particle|
         [
@@ -1744,7 +1763,10 @@ pub fn sputtering_yield(ion: &PyDict, target: &PyDict, energy: f64, angle: f64, 
 
     let num_sputtered = Mutex::new(0);
 
-    (0..num_samples as u64).into_par_iter().for_each( |index| {
+    static SEED: u64 = 0;
+    (0..num_samples as u64).into_par_iter()
+    .for_each_init(
+        || ChaCha8Rng::seed_from_u64(SEED), |rng, index| {
 
         let p = particle::Particle::default_incident(
             m1,
@@ -1757,7 +1779,8 @@ pub fn sputtering_yield(ion: &PyDict, target: &PyDict, energy: f64, angle: f64, 
             uy,
             uz
         );
-
+        
+        rng.set_stream(index);
         let output = bca::single_ion_bca(p, &m, &options);
 
         for particle in output {
@@ -1839,7 +1862,10 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
     let num_reflected = Mutex::new(0);
     let energy_reflected = Mutex::new(0.0);
 
-    (0..num_samples as u64).into_par_iter().for_each( |index| {
+    static SEED: u64 = 0;
+    (0..num_samples as u64).into_par_iter()
+    .for_each_init(
+        || ChaCha8Rng::seed_from_u64(SEED), |rng, index| {
 
         let p = particle::Particle::default_incident(
             m1,
@@ -1852,7 +1878,8 @@ pub fn reflection_coefficient(ion: &PyDict, target: &PyDict, energy: f64, angle:
             uy,
             uz
         );
-
+        
+        rng.set_stream(index);
         let output = bca::single_ion_bca(p, &m, &options);
 
         for particle in output {
@@ -1940,7 +1967,10 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
     let num_reflected = Mutex::new(0);
     let energy_reflected = Mutex::new(0.0);
 
-    (0..num_samples as u64).into_par_iter().for_each( |index| {
+    static SEED: u64 = 0;
+    (0..num_samples as u64).into_par_iter()
+    .for_each_init(
+        || ChaCha8Rng::seed_from_u64(SEED), |rng, index| {
 
         let p = particle::Particle::default_incident(
             m1,
@@ -1953,7 +1983,8 @@ pub fn compound_reflection_coefficient(ion: &PyDict, targets: Vec<&PyDict>, targ
             uy,
             uz
         );
-
+        
+        rng.set_stream(index);
         let output = bca::single_ion_bca(p, &m, &options);
 
         for particle in output {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ pub extern "C" fn compound_tagged_bca_list_c(input: InputTaggedBCA) -> OutputTag
             tracked_vector: Vector::new(positions[index][0], positions[index][1], positions[index][2]),
         };
 
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut rng = ChaCha8Rng::seed_from_u64(index as u64);
         let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
@@ -427,7 +427,7 @@ pub extern "C" fn reflect_single_ion_c(num_species_target: &mut c_int, ux: &mut 
         tracked_vector: Vector::new(0.0, 0.0, 0.0),
     };
 
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
     let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
     *ux = output[0].dir.x;
@@ -475,6 +475,7 @@ pub extern "C" fn simple_bca_list_c(input: InputSimpleBCA) -> OutputBCA {
 
     let velocities = unsafe { slice::from_raw_parts(input.velocities, input.len) };
 
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
     for velocity in velocities {
 
         let vx = velocity[0];
@@ -518,7 +519,6 @@ pub extern "C" fn simple_bca_list_c(input: InputSimpleBCA) -> OutputBCA {
             tracked_vector: Vector::new(0.0, 0.0, 0.0),
         };
 
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
         let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
@@ -593,6 +593,7 @@ pub extern "C" fn compound_bca_list_c(input: InputCompoundBCA) -> OutputBCA {
 
     let velocities = unsafe { slice::from_raw_parts(input.velocities, input.len) };
 
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
     for velocity in velocities {
 
         let vx = velocity[0];
@@ -636,7 +637,6 @@ pub extern "C" fn compound_bca_list_c(input: InputCompoundBCA) -> OutputBCA {
             tracked_vector: Vector::new(0.0, 0.0, 0.0),
         };
 
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
         let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {
@@ -730,6 +730,7 @@ pub extern "C" fn compound_bca_list_fortran(num_incident_ions: &mut c_int, track
 
     let m = material::Material::<Mesh0D>::new(&material_parameters, &geometry_input);
 
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
     for (((((((E1_, ux_), uy_), uz_), Z1_), Ec1_), Es1_), m1_) in E1.iter().zip(ux).zip(uy).zip(uz).zip(Z1).zip(Ec1).zip(Es1).zip(m1) {
 
         let p = particle::Particle {
@@ -761,7 +762,7 @@ pub extern "C" fn compound_bca_list_fortran(num_incident_ions: &mut c_int, track
             tracked_vector: Vector::new(0.0, 0.0, 0.0)
         };
 
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        
         let output = bca::single_ion_bca(p, &m, &options, &mut rng);
 
         for particle in output {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ pub extern "C" fn compound_tagged_bca_list_c(input: InputTaggedBCA) -> OutputTag
     let tags = unsafe { slice::from_raw_parts(input.tags, input.len).to_vec() };
     let weights = unsafe { slice::from_raw_parts(input.weights, input.len).to_vec() };
 
-    let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
+    let x = -2.*(n2.iter().sum::<f64>()*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -368,7 +368,7 @@ pub extern "C" fn reflect_single_ion_c(num_species_target: &mut c_int, ux: &mut 
     let Es2 = unsafe { slice::from_raw_parts(Es2, *num_species_target as usize).to_vec() };
     let Eb2 = unsafe { slice::from_raw_parts(Eb2, *num_species_target as usize).to_vec() };
 
-    let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
+    let x = -2.*(n2.iter().sum::<f64>()*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -438,7 +438,7 @@ pub extern "C" fn reflect_single_ion_c(num_species_target: &mut c_int, ux: &mut 
 #[no_mangle]
 pub extern "C" fn simple_bca_list_c(input: InputSimpleBCA) -> OutputBCA {
 
-    let x = -2.*(input.n2*10E30).powf(-1./3.);
+    let x = -2.*(input.n2*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -560,7 +560,7 @@ pub extern "C" fn compound_bca_list_c(input: InputCompoundBCA) -> OutputBCA {
     let Es2 = unsafe { slice::from_raw_parts(input.Es2, input.num_species_target).to_vec() };
     let Eb2 = unsafe { slice::from_raw_parts(input.Eb2, input.num_species_target).to_vec() };
 
-    let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
+    let x = -2.*(n2.iter().sum::<f64>()*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -699,7 +699,7 @@ pub extern "C" fn compound_bca_list_fortran(num_incident_ions: &mut c_int, track
 
     //println!("Z2: {} m2: {} n2: {} Ec2: {} Es2: {} Eb2: {}", Z2[0], m2[0], n2[0], Ec2[0], Es2[0], Eb2[0]);
 
-    let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
+    let x = -2.*(n2.iter().sum::<f64>()*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -844,7 +844,7 @@ pub fn compound_bca_list_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f64>, uz: 
 
     let options = Options::default_options(true);
 
-    let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
+    let x = -2.*(n2.iter().sum::<f64>()*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -968,7 +968,7 @@ pub fn compound_bca_list_tracked_py(energies: Vec<f64>, ux: Vec<f64>, uy: Vec<f6
     let options = Options::default_options(true);
     //options.high_energy_free_flight_paths = true;
 
-    let x = -2.*(n2.iter().sum::<f64>()*10E30).powf(-1./3.);
+    let x = -2.*(n2.iter().sum::<f64>()*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -1333,7 +1333,7 @@ pub fn simple_bca_list_py(energies: Vec<f64>, usx: Vec<f64>, usy: Vec<f64>, usz:
     assert_eq!(energies.len(), usy.len());
     assert_eq!(energies.len(), usz.len());
 
-    let x = -2.*(n2*10E30).powf(-1./3.);
+    let x = -2.*(n2*1E30).powf(-1./3.);
     let y = 0.0;
     let z = 0.0;
 
@@ -1525,7 +1525,7 @@ pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mu
     *ux = incident.x;
     *uy = incident.y;
     *uz = incident.z;
-    let mag = (ux.powf(2.) + uy.powf(2.) + uz.powf(2.)).sqrt();
+    let mag = (ux*ux + uy*uy + uz*uz).sqrt();
 
     *ux /= mag;
     *uy /= mag;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,10 @@ use std::f64::consts::FRAC_2_SQRT_PI;
 use std::f64::consts::PI;
 use std::f64::consts::SQRT_2;
 
+//RNG
+use rand::{RngExt, SeedableRng, rngs::ChaCha8Rng};
+use rand_distr::{Normal, Distribution, Uniform};
+
 //Load internal modules
 pub mod material;
 pub mod particle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,7 @@ use std::f64::consts::PI;
 use std::f64::consts::SQRT_2;
 
 //RNG
-use rand::{RngExt, SeedableRng, rngs::ChaCha8Rng};
-use rand_distr::{Normal, Distribution, Uniform};
+use rand::{SeedableRng, rngs::ChaCha8Rng};
 
 //Load internal modules
 pub mod material;

--- a/src/material.rs
+++ b/src/material.rs
@@ -121,7 +121,7 @@ impl <T: Geometry> Material<T> {
 
     /// Determines the local mean free path from the formula sum(n(x, y))^(-1/3)
     pub fn mfp(&self, x: f64, y: f64, z: f64) -> f64 {
-        return self.total_number_density(x, y, z).powf(-1./3.);
+        return 1./self.total_number_density(x, y, z).cbrt();
     }
 
     /// Total number density of triangle that contains or is nearest to (x, y).
@@ -274,7 +274,7 @@ impl <T: Geometry> Material<T> {
 
         for (n, Zb) in self.number_densities(x, y, z).iter().zip(&self.Z) {
 
-            let beta = (1. - (1. + E/Ma/C.powi(2)).powf(-2.)).sqrt();
+            let beta = (1. - 1./(1. + E/Ma/C.powi(2)).sqrt()).sqrt();
             let v = beta*C;
 
             // This term is an empirical fit to the mean ionization potential
@@ -296,7 +296,8 @@ impl <T: Geometry> Material<T> {
             let S_high = prefactor*(eb + 1. + B/eb).ln();
 
             //Lindhard-Scharff electronic stopping
-            let S_low = LINDHARD_SCHARFF_PREFACTOR*(Za.powf(7./6.)*Zb)/(Za.powf(2./3.) + Zb.powf(2./3.)).powf(3./2.)*(E/Q/Ma*AMU).sqrt();
+            //let S_low = LINDHARD_SCHARFF_PREFACTOR*(Za.powf(7./6.)*Zb)/(Za.powf(2./3.) + Zb.powf(2./3.)).powf(3./2.)*(E/Q/Ma*AMU).sqrt();
+            let S_low = LINDHARD_SCHARFF_PREFACTOR*(Za*Za.cbrt().sqrt()*Zb)/(Za.cbrt().powi(2) + Zb.cbrt().powi(2)).powi(3).sqrt()*(E/Q/Ma*AMU).sqrt();
 
             let stopping_power = match electronic_stopping_mode {
                 //Biersack-Varelas Interpolation

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rand::RngExt;
 
 ///This helper function is a workaround to issue #368 in serde
 fn default_surface_binding_model() -> SurfaceBindingModel {
@@ -243,8 +244,8 @@ impl <T: Geometry> Material<T> {
     }
 
     ///Choose the parameters of a target atom as a concentration-weighted random draw from the species in the triangle that contains or is nearest to (x, y).
-    pub fn choose(&self, x: f64, y: f64, z: f64) -> (usize, f64, f64, f64, f64, f64, usize) {
-        let random_number: f64 = rand::random::<f64>();
+    pub fn choose(&self, x: f64, y: f64, z: f64, rng: &mut ChaCha8Rng) -> (usize, f64, f64, f64, f64, f64, usize) {
+        let random_number: f64 = rng.random::<f64>();
         let cumulative_concentrations = self.get_cumulative_concentrations(x, y, z);
 
         for (component_index, cumulative_concentration) in cumulative_concentrations.iter().enumerate() {

--- a/src/material.rs
+++ b/src/material.rs
@@ -274,7 +274,7 @@ impl <T: Geometry> Material<T> {
 
         for (n, Zb) in self.number_densities(x, y, z).iter().zip(&self.Z) {
 
-            let beta = (1. - 1./(1. + E/Ma/C.powi(2)).sqrt()).sqrt();
+            let beta = (1. - 1./(1. + E/Ma/C.powi(2)).powi(2)).sqrt();
             let v = beta*C;
 
             // This term is an empirical fit to the mean ionization potential

--- a/src/material.rs
+++ b/src/material.rs
@@ -61,18 +61,14 @@ impl <T: Geometry> Material<T> {
             "KEV" => EV*1E3,
             "MEV" => EV*1E6,
             _ => material_parameters.energy_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse energy unit {}. Use a valid float or one of EV, J, KEV, MEV", &material_parameters.energy_unit.as_str()
-                    ).as_str()),
+                .unwrap_or_else(|_| panic!("Input errror: could nor parse energy unit {}. Use a valid float or one of EV, J, KEV, MEV", &material_parameters.energy_unit.as_str())),
         };
 
         let mass_unit: f64 = match material_parameters.mass_unit.as_str() {
             "AMU" => AMU,
             "KG" => 1.,
             _ => material_parameters.mass_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse mass unit {}. Use a valid float or one of AMU, KG", &material_parameters.mass_unit.as_str()
-                    ).as_str()),
+                .unwrap_or_else(|_| panic!("Input errror: could nor parse mass unit {}. Use a valid float or one of AMU, KG", &material_parameters.mass_unit.as_str())),
         };
 
         Material {
@@ -94,7 +90,7 @@ impl <T: Geometry> Material<T> {
 
         let total_number_density: f64 = self.geometry.get_total_density(x, y, z);
 
-        return self.geometry.get_densities(x, y, z).iter().map(|&i| i / total_number_density).collect();
+        self.geometry.get_densities(x, y, z).iter().map(|&i| i / total_number_density).collect()
     }
 
     /// Gets cumulative concentrations of triangle that contains or is nearest to (x, y).
@@ -107,22 +103,22 @@ impl <T: Geometry> Material<T> {
             sum += concentration;
             cumulative_concentrations.push(sum);
         }
-        return cumulative_concentrations;
+        cumulative_concentrations
     }
 
     /// Determines whether (x, y) is inside the material.
     pub fn inside(&self, x: f64, y: f64, z: f64) -> bool {
-        return self.geometry.inside(x, y, z);
+        self.geometry.inside(x, y, z)
     }
 
     /// Gets electronic stopping correction factor for LS and OR
     pub fn electronic_stopping_correction_factor(&self, x: f64, y: f64, z: f64) -> f64 {
-        return self.geometry.get_ck(x, y, z);
+        self.geometry.get_ck(x, y, z)
     }
 
     /// Determines the local mean free path from the formula sum(n(x, y))^(-1/3)
     pub fn mfp(&self, x: f64, y: f64, z: f64) -> f64 {
-        return 1./self.total_number_density(x, y, z).cbrt();
+        1./self.total_number_density(x, y, z).cbrt()
     }
 
     /// Total number density of triangle that contains or is nearest to (x, y).
@@ -132,7 +128,7 @@ impl <T: Geometry> Material<T> {
 
     /// Lists number density of each species of triangle that contains or is nearest to (x, y).
     pub fn number_densities(&self, x: f64, y: f64, z: f64) -> &Vec<f64> {
-        return &self.geometry.get_densities(x, y, z);
+        self.geometry.get_densities(x, y, z)
     }
 
     /// Determines whether a point (x, y) is inside the energy barrier of the material.
@@ -142,7 +138,7 @@ impl <T: Geometry> Material<T> {
 
     /// Determines whether a point (x, y) is inside the simulation boundary.
     pub fn inside_simulation_boundary(&self, x:f64, y: f64, z: f64) -> bool {
-        return self.geometry.inside_simulation_boundary(x, y, z);
+        self.geometry.inside_simulation_boundary(x, y, z)
     }
 
     /// Finds the closest point on the material boundary to the point (x, y).
@@ -153,20 +149,20 @@ impl <T: Geometry> Material<T> {
     /// Finds the average, concentration-weighted atomic number, Z_effective, of the triangle that contains or is nearest to (x, y).
     pub fn average_Z(&self, x: f64, y: f64, z: f64) -> f64 {
         let concentrations = self.geometry.get_concentrations(x, y, z);
-        return self.Z.iter().zip(concentrations).map(|(charge, concentration)| charge*concentration).collect::<Vec<f64>>().iter().sum();
+        self.Z.iter().zip(concentrations).map(|(charge, concentration)| charge*concentration).collect::<Vec<f64>>().iter().sum()
     }
 
     /// Finds the average, concentration-weighted atomic mass, m_effective, of the triangle that contains or is nearest to (x, y).
     pub fn average_mass(&self, x: f64, y: f64, z: f64) -> f64 {
         let concentrations = self.geometry.get_concentrations(x, y, z);
-        return self.m.iter().zip(concentrations).map(|(mass, concentration)| mass*concentration).collect::<Vec<f64>>().iter().sum();
+        self.m.iter().zip(concentrations).map(|(mass, concentration)| mass*concentration).collect::<Vec<f64>>().iter().sum()
     }
 
     /// Finds the average, concentration-weighted bulk binding energy of the triangle that contains or is nearest to (x, y).
     pub fn average_bulk_binding_energy(&self, x: f64, y: f64, z: f64) -> f64 {
         //returns average bulk binding energy
         let concentrations = self.geometry.get_concentrations(x, y, z);
-        return self.Eb.iter().zip(concentrations).map(|(bulk_binding_energy, concentration)| bulk_binding_energy*concentration).collect::<Vec<f64>>().iter().sum();
+        self.Eb.iter().zip(concentrations).map(|(bulk_binding_energy, concentration)| bulk_binding_energy*concentration).collect::<Vec<f64>>().iter().sum()
     }
 
     pub fn actual_bulk_binding_energy(&self, species_index: usize, x: f64, y: f64, z: f64) -> f64 {
@@ -240,7 +236,7 @@ impl <T: Geometry> Material<T> {
                 min_Ec = *Ec;
             }
         }
-        return min_Ec;
+        min_Ec
     }
 
     ///Choose the parameters of a target atom as a concentration-weighted random draw from the species in the triangle that contains or is nearest to (x, y).
@@ -313,7 +309,7 @@ impl <T: Geometry> Material<T> {
 
             stopping_powers.push(stopping_power);
         }
-        return stopping_powers;
+        stopping_powers
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -223,11 +223,11 @@ impl SummaryPerSpecies {
     pub fn print(&mut self, options: &Options, output_units: &OutputUnits) {
         //Write to summary file
         writeln!(self.summary_stream_file, "mass, reflected, sputtered, deposited")
-            .expect(format!("Output error: could not write to {}summary.output.", options.name).as_str());
+            .unwrap_or_else(|_| panic!("Output error: could not write to {}summary.output.", options.name));
 
         for (mass, reflected, sputtered, deposited) in izip!(&self.m, &self.reflected, &self.sputtered, &self.deposited) {
             writeln!(self.summary_stream_file, "{}, {}, {}, {},", mass/output_units.mass_unit, reflected, sputtered, deposited)
-                .expect(format!("Output error: could not write to {}summary.output.", options.name).as_str());
+                .unwrap_or_else(|_| panic!("Output error: could not write to {}summary.output.", options.name));
         }
         self.summary_stream_file.flush().unwrap();
     }
@@ -346,7 +346,7 @@ pub fn output_lists(output_list_streams: &mut OutputListStreams, particle: parti
             particle.m/mass_unit, particle.Z, particle.energy_origin/energy_unit,
             particle.pos_origin.x/length_unit, particle.pos_origin.y/length_unit, particle.pos_origin.z/length_unit,
             particle.pos.x/length_unit, particle.pos.y/length_unit, particle.pos.z/length_unit
-        ).expect(format!("Output error: could not write to {}displacements.output.", options.name).as_str());
+        ).unwrap_or_else(|_| panic!("Output error: could not write to {}displacements.output.", options.name));
     }
 
     //Incident particle, left simulation: reflected
@@ -357,7 +357,7 @@ pub fn output_lists(output_list_streams: &mut OutputListStreams, particle: parti
             particle.pos.x/length_unit, particle.pos.y/length_unit, particle.pos.z/length_unit,
             particle.dir.x, particle.dir.y, particle.dir.z,
             particle.number_collision_events
-        ).expect(format!("Output error: could not write to {}reflected.output.", options.name).as_str());
+        ).unwrap_or_else(|_| panic!("Output error: could not write to {}reflected.output.", options.name));
     }
 
     //Incident particle, stopped in material: deposited
@@ -367,7 +367,7 @@ pub fn output_lists(output_list_streams: &mut OutputListStreams, particle: parti
             particle.m/mass_unit, particle.Z,
             particle.pos.x/length_unit, particle.pos.y/length_unit, particle.pos.z/length_unit,
             particle.number_collision_events
-        ).expect(format!("Output error: could not write to {}deposited.output.", options.name).as_str());
+        ).unwrap_or_else(|_| panic!("Output error: could not write to {}deposited.output.", options.name));
     }
 
     //Not an incident particle, left material: sputtered
@@ -379,20 +379,20 @@ pub fn output_lists(output_list_streams: &mut OutputListStreams, particle: parti
             particle.dir.x, particle.dir.y, particle.dir.z,
             particle.number_collision_events,
             particle.pos_origin.x/length_unit, particle.pos_origin.y/length_unit, particle.pos_origin.z/length_unit
-        ).expect(format!("Output error: could not write to {}sputtered.output.", options.name).as_str());
+        ).unwrap_or_else(|_| panic!("Output error: could not write to {}sputtered.output.", options.name));
     }
 
     //Trajectory output
     if particle.track_trajectories {
         writeln!(output_list_streams.trajectory_data_stream, "{}", particle.trajectory.len())
-            .expect(format!("Output error: could not write to {}trajectory_data.output.", options.name).as_str());
+            .unwrap_or_else(|_| panic!("Output error: could not write to {}trajectory_data.output.", options.name));
 
         for pos in particle.trajectory {
             writeln!(
                 output_list_streams.trajectory_file_stream, "{},{},{},{},{},{}",
                 particle.m/mass_unit, particle.Z, pos.E/energy_unit,
                 pos.x/length_unit, pos.y/length_unit, pos.z/length_unit,
-            ).expect(format!("Output error: could not write to {}trajectories.output.", options.name).as_str());
+            ).unwrap_or_else(|_| panic!("Output error: could not write to {}trajectories.output.", options.name));
         }
     }
 
@@ -403,7 +403,7 @@ pub fn output_lists(output_list_streams: &mut OutputListStreams, particle: parti
                 particle.m/mass_unit, particle.Z,
                 energy_loss.En/energy_unit, energy_loss.Ee/energy_unit,
                 energy_loss.x/length_unit, energy_loss.y/length_unit, energy_loss.z/length_unit,
-            ).expect(format!("Output error: could not write to {}energy_loss.output.", options.name).as_str());
+            ).unwrap_or_else(|_| panic!("Output error: could not write to {}energy_loss.output.", options.name));
         }
     }
 }

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -179,7 +179,7 @@ impl Particle {
 
         Particle {
             m: m_amu*AMU,
-            Z: Z,
+            Z,
             E: E_eV*EV,
             Ec: Ec_eV*EV,
             Es: Es_eV*EV,
@@ -296,7 +296,7 @@ impl Particle {
         self.dir_old.y = self.dir.y;
         self.dir_old.z = self.dir.z;
 
-        return distance_traveled;
+        distance_traveled
     }
 }
 
@@ -322,5 +322,5 @@ pub fn refraction_angle(costheta: f64, energy_old: f64, energy_new: f64) -> f64 
     let delta_theta = sintheta1.asin() - sintheta0.asin();
     assert!(!delta_theta.is_nan(), "Numerical error: refraction returned NaN.");
     let sign = -costheta.signum();
-    return sign*delta_theta;
+    sign*delta_theta
 }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -28,7 +28,8 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
             .progress_chars("#>-"));
 
         //Main loop
-        for (chunk_index, particle_input_chunk) in particle_input_array.chunks((total_count/options.num_chunks) as usize).enumerate() {
+        let chunk_size = (total_count/options.num_chunks) as usize;
+        for (chunk_index, particle_input_chunk) in particle_input_array.chunks(chunk_size).enumerate() {
 
             let mut finished_particles: Vec<particle::Particle> = Vec::new();
 
@@ -40,7 +41,7 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
                 .map_init(
                     || ChaCha8Rng::seed_from_u64(SEED),
                     | rng, (particle_index, particle_input)| {
-                        rng.set_stream(particle_index as u64);
+                        rng.set_stream((chunk_index * chunk_size + particle_index) as u64);
                         bar.tick();
                         bar.inc(1);
                         bca::single_ion_bca(particle::Particle::from_input(*particle_input, &options), &material, &options, rng)

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -4,8 +4,6 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
 
         println!("Processing {} ions...", particle_input_array.len());
 
-        static SEED: u64 = 0;
-
         let total_count: u64 = particle_input_array.len() as u64;
         assert!(total_count/options.num_chunks > 0, "Input error: chunk size == 0 - reduce num_chunks or increase particle count.");
 
@@ -39,7 +37,7 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
                 particle_input_chunk.into_par_iter()
                 .enumerate()
                 .map_init(
-                    || ChaCha8Rng::seed_from_u64(SEED),
+                    || ChaCha8Rng::seed_from_u64(options.seed),
                     | rng, (particle_index, particle_input)| {
                         rng.set_stream((chunk_index * chunk_size + particle_index) as u64);
                         bar.tick();

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -4,6 +4,8 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
 
         println!("Processing {} ions...", particle_input_array.len());
 
+        static SEED: u64 = 0;
+
         let total_count: u64 = particle_input_array.len() as u64;
         assert!(total_count/options.num_chunks > 0, "Input error: chunk size == 0 - reduce num_chunks or increase particle count.");
 
@@ -34,10 +36,14 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
             // finished particle array via map from particle -> finished particles via BCA
             finished_particles.par_extend(
                 particle_input_chunk.into_par_iter()
-                .map(|particle_input| {
-                    bar.tick();
-                    bar.inc(1);
-                    bca::single_ion_bca(particle::Particle::from_input(*particle_input, &options), &material, &options)
+                .enumerate()
+                .map_init(
+                    || ChaCha8Rng::seed_from_u64(SEED),
+                    | rng, (particle_index, particle_input)| {
+                        rng.set_stream(particle_index as u64);
+                        bar.tick();
+                        bar.inc(1);
+                        bca::single_ion_bca(particle::Particle::from_input(*particle_input, &options), &material, &options, rng)
                 }).flatten()
             );
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -17,7 +17,7 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
 
         //Initialize threads with rayon
         println!("Initializing with {} threads...", options.num_threads);
-        let pool = rayon::ThreadPoolBuilder::new().num_threads(options.num_threads).build_global().unwrap();
+        rayon::ThreadPoolBuilder::new().num_threads(options.num_threads).build_global().unwrap();
 
         //Create and configure progress bar
         let bar: ProgressBar = ProgressBar::new(total_count);
@@ -37,7 +37,11 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
                 particle_input_chunk.into_par_iter()
                 .enumerate()
                 .map_init(
-                    || ChaCha8Rng::seed_from_u64(options.seed),
+                    || if options.seed < 0 { 
+                        ChaCha8Rng::seed_from_u64(rand::random())
+                    } else {
+                        ChaCha8Rng::seed_from_u64(u64::try_from(options.seed).expect("Value Error: seed not u64."))
+                    },
                     | rng, (particle_index, particle_input)| {
                         rng.set_stream((chunk_index * chunk_size + particle_index) as u64);
                         bar.tick();

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -17,7 +17,7 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
 
         //Initialize threads with rayon
         println!("Initializing with {} threads...", options.num_threads);
-        if options.num_threads > 1 {let pool = rayon::ThreadPoolBuilder::new().num_threads(options.num_threads).build_global().unwrap();};
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(options.num_threads).build_global().unwrap();
 
         //Create and configure progress bar
         let bar: ProgressBar = ProgressBar::new(total_count);
@@ -30,27 +30,16 @@ pub fn physics_loop<T: Geometry + Sync>(particle_input_array: Vec<particle::Part
 
             let mut finished_particles: Vec<particle::Particle> = Vec::new();
 
-            if options.num_threads > 1 {
-                // BCA loop is implemented as parallelized extension of a per-chunk initially empty
-                // finished particle array via map from particle -> finished particles via BCA
-                finished_particles.par_extend(
-                    particle_input_chunk.into_par_iter()
-                    .map(|particle_input| {
-                        bar.tick();
-                        bar.inc(1);
-                        bca::single_ion_bca(particle::Particle::from_input(*particle_input, &options), &material, &options)
-                    }).flatten()
-                );
-            } else {
-                finished_particles.extend(
-                    particle_input_chunk.iter()
-                    .map(|particle_input| {
-                        bar.tick();
-                        bar.inc(1);
-                        bca::single_ion_bca(particle::Particle::from_input(*particle_input, &options), &material, &options)
-                    }).flatten()
-                );
-            }
+            // BCA loop is implemented as parallelized extension of a per-chunk initially empty
+            // finished particle array via map from particle -> finished particles via BCA
+            finished_particles.par_extend(
+                particle_input_chunk.into_par_iter()
+                .map(|particle_input| {
+                    bar.tick();
+                    bar.inc(1);
+                    bca::single_ion_bca(particle::Particle::from_input(*particle_input, &options), &material, &options)
+                }).flatten()
+            );
 
             // Process this chunk of finished particles for output
             for particle in finished_particles {

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -63,10 +63,8 @@ impl Geometry for Sphere {
             "NM" => NM,
             "M" => 1.,
             _ => input.length_unit.parse()
-                .expect(format!(
-                        "Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M",
-                        &input.length_unit.as_str()
-                    ).as_str()),
+                .unwrap_or_else(|_| panic!("Input errror: could nor parse length unit {}. Use a valid float or one of ANGSTROM, NM, MICRON, CM, MM, M",
+                        &input.length_unit.as_str())),
         };
 
         let electronic_stopping_correction_factor = input.electronic_stopping_correction_factor;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -929,7 +929,7 @@ fn test_momentum_conservation() {
                             binary_collision_geometries[0].mfp/ANGSTROM);
 
                         let (species_index, mut particle_2) = bca::choose_collision_partner(&mut particle_1, &material_1,
-                            &binary_collision_geometries[0], &options);
+                            &binary_collision_geometries[0], &options, &mut rng);
 
                         let mom1_0 = particle_1.get_momentum();
                         let mom2_0 = particle_2.get_momentum();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -920,7 +920,9 @@ fn test_momentum_conservation() {
                             z_num: 11,
                         };
 
-                        let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material_1, &options);
+                        static SEED: u64 = 0;
+                        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+                        let binary_collision_geometries = bca::determine_mfp_phi_impact_parameter(&mut particle_1, &material_1, &options, &mut rng);
 
                         println!("Phi: {} rad p: {} Angstrom mfp: {} Angstrom", binary_collision_geometries[0].phi_azimuthal,
                             binary_collision_geometries[0].impact_parameter/ANGSTROM,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,6 +229,7 @@ fn test_distributions() {
         root_finder: vec![vec![Rootfinder::NEWTON{max_iterations: 100, tolerance: 1E-3}]],
         track_displacements: false,
         track_energy_losses: true,
+        seed: 0,
         energy_min: 0.0,
         energy_max: 10.0,
         energy_num: 11,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -881,6 +881,7 @@ fn test_momentum_conservation() {
                             root_finder: vec![vec![root_finder]],
                             track_displacements: false,
                             track_energy_losses: false,
+                            seed: 0,
                         };
 
                         #[cfg(feature = "distributions")]
@@ -903,6 +904,7 @@ fn test_momentum_conservation() {
                             root_finder: vec![vec![root_finder]],
                             track_displacements: false,
                             track_energy_losses: false,
+                            seed: 0,
                             energy_min: 0.0,
                             energy_max: 10.0,
                             energy_num: 11,
@@ -1085,6 +1087,7 @@ fn test_quadrature() {
         root_finder: vec![vec![Rootfinder::NEWTON{max_iterations: 100, tolerance: 1E-14}]],
         track_displacements: false,
         track_energy_losses: false,
+        seed: 0,
     };
 
     #[cfg(feature = "distributions")]
@@ -1107,6 +1110,7 @@ fn test_quadrature() {
         root_finder: vec![vec![Rootfinder::NEWTON{max_iterations: 100, tolerance: 1E-14}]],
         track_displacements: false,
         track_energy_losses: false,
+        seed: 0,
         energy_min: 0.0,
         energy_max: 10.0,
         energy_num: 11,


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #308, #306, #305, #310

## Description
This PR adds a seeded RNG (ChaCha8) to make RustBCA deterministic; as a first pass, the seed will be hardcoded - before merge, I'd like to have it be an optional input parameter.

This also rolls in the powf -> powi optimizations (there's a minor performance cost to determinism that is basically completely counteracted by these optimizations) and the Biersack-Varelas stopping power correction factor change.

I've also updated the README doctests to take advantage of the new determinism.

Remaining tasks:

- [x] add ability to specify seed
- [x] investigate feasibility of environment variable seed for python functions
- [x] update docs once code updates finished and merged into dev to include implementation details

## Tests
Cargo test passes; using CI to make sure nothing's broken. See below plots for additional testing
