### PR TITLE
Experimental recoil generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ materials.py is intended to provide example input values only; all input values 
 >>> angle = 0.0 # deg
 >>> energy = 1000.0 # eV
 >>> num_samples = 10000
->>> sputtering_yield(argon, tungsten, energy, angle, num_samples) == 1.0243
+>>> sputtering_yield(argon, tungsten, energy, angle, num_samples) == 1.0291
 True
 >>> R_N, R_E = reflection_coefficient(argon, tungsten, energy, angle, num_samples)
->>> R_N == 0.3234
+>>> R_N == 0.3297
 True
->>> np.testing.assert_approx_equal(R_E, 0.09645129485419984)
+>>> np.testing.assert_approx_equal(R_E, 0.09767736052353852)
 ```
 
 For those eager to get started with the standalone code, try running one of the examples in the

--- a/examples/make_input_file_and_run.py
+++ b/examples/make_input_file_and_run.py
@@ -144,6 +144,7 @@ options = {
             }
         ]
     ],
+    'seed': 0 # if <0, will generate a seed from thread-local PRNG; if >0, will be used as seed to PRNG
 }
 
 # material parameters are per-species

--- a/examples/make_input_file_and_run.py
+++ b/examples/make_input_file_and_run.py
@@ -17,7 +17,7 @@ It includes two geometry modes, 1D and 0D.
 
 It simulates the following situations:
 
-if mode == '1D': 
+if mode == '1D':
     H+ (1 keV)
     |
     V
@@ -61,7 +61,7 @@ angle = 45.0 # degrees; measured from surface normal
 
 '''
 For organizational purposes, species are commonly defined in dictionaries.
-Additional examples can be found in scripts/materials.py, but values 
+Additional examples can be found in scripts/materials.py, but values
 should be checked for correctness before use. Values are explained
 in the relevant sections below.
 '''
@@ -199,7 +199,7 @@ particle_parameters = {
     'm': [ion["m"]],
     # atomic number
     'Z': [ion["Z"]],
-    # incidenet energy 
+    # incidenet energy
     'E': [incident_energy],
     # cutoff energy - if E < Ec, particle stops
     'Ec': [ion["Ec"]],
@@ -230,7 +230,7 @@ geometry_1D = {
     'length_unit': 'ANGSTROM',
     # used to correct nonlocal stopping for known compound discrpancies
     'electronic_stopping_correction_factors': [1.0, 1.0, 1.0],
-    # thickness of each layer in order from top (x=0) to bottom 
+    # thickness of each layer in order from top (x=0) to bottom
     'layer_thicknesses': layer_thicknesses,
     # number densitiy of each layer in order from top to bottom
     'densities': [
@@ -260,26 +260,30 @@ input_string = dumps(input_data).replace('\r', '')
 with  open('examples/input_file.toml', 'w') as input_file:
     input_file.write(input_string)
 
-if run_sim:
-    os.system(f'cargo run --release {mode} examples/input_file.toml')
+branches_to_test = ['dev', 'experimental_recoil_generation', 'improved_duff']
 
-# Read output files - ensure arrays are at least 2D for indexing
-sputtered = np.atleast_2d(np.genfromtxt('input_filesputtered.output', delimiter=','))
-reflected = np.atleast_2d(np.genfromtxt('input_filereflected.output', delimiter=','))
-implanted = np.atleast_2d(np.genfromtxt('input_filedeposited.output', delimiter=','))
+for branch in branches_to_test:
+    if run_sim:
+        os.system(f'git checkout {branch}')
+        os.system(f'cargo run --release {mode} examples/input_file.toml')
 
-print('H on B-TiB2-Ti')
-print(f'R_N, R_E: {np.size(reflected[:, 0])/number_ions}, {np.sum(reflected[:, 2]/incident_energy/number_ions)}')
-print(f'Y: {np.size(sputtered[:, 0])/number_ions} [at./ion]')
-print()
-print('H on B (default settings)')
-print(f'Y: {sputtering_yield(hydrogen, boron, incident_energy, angle, 10000)} [at./ion]')
-print(f'R_N, R_E: {reflection_coefficient(hydrogen, boron, incident_energy, angle, 10000)}')
+    # Read output files - ensure arrays are at least 2D for indexing
+    sputtered = np.atleast_2d(np.genfromtxt('input_filesputtered.output', delimiter=','))
+    reflected = np.atleast_2d(np.genfromtxt('input_filereflected.output', delimiter=','))
+    implanted = np.atleast_2d(np.genfromtxt('input_filedeposited.output', delimiter=','))
 
-x = implanted[:, 2]
-num_bins=100
-bins = np.linspace(0.0, 500.0, num_bins)
-plt.hist(x, bins=bins, histtype='step')
+    print('H on B-TiB2-Ti')
+    print(f'R_N, R_E: {np.size(reflected[:, 0])/number_ions}, {np.sum(reflected[:, 2]/incident_energy/number_ions)}')
+    print(f'Y: {np.size(sputtered[:, 0])/number_ions} [at./ion]')
+    print()
+    print('H on B (default settings)')
+    print(f'Y: {sputtering_yield(hydrogen, boron, incident_energy, angle, 10000)} [at./ion]')
+    print(f'R_N, R_E: {reflection_coefficient(hydrogen, boron, incident_energy, angle, 10000)}')
+
+    x = implanted[:, 2]
+    num_bins=100
+    bins = np.linspace(0.0, 500.0, num_bins)
+    plt.hist(x, bins=bins, histtype='step', label=branch)
 if mode == '1D':
     plt.plot([layer_thicknesses[0], layer_thicknesses[0]], [0.0, number_ions], color='gray')
     plt.plot([layer_thicknesses[0] + layer_thicknesses[1], layer_thicknesses[0] + layer_thicknesses[1]], [0.0, number_ions], linestyle='--', color='gray')

--- a/examples/make_input_file_and_run.py
+++ b/examples/make_input_file_and_run.py
@@ -17,7 +17,7 @@ It includes two geometry modes, 1D and 0D.
 
 It simulates the following situations:
 
-if mode == '1D':
+if mode == '1D': 
     H+ (1 keV)
     |
     V
@@ -61,7 +61,7 @@ angle = 45.0 # degrees; measured from surface normal
 
 '''
 For organizational purposes, species are commonly defined in dictionaries.
-Additional examples can be found in scripts/materials.py, but values
+Additional examples can be found in scripts/materials.py, but values 
 should be checked for correctness before use. Values are explained
 in the relevant sections below.
 '''
@@ -199,7 +199,7 @@ particle_parameters = {
     'm': [ion["m"]],
     # atomic number
     'Z': [ion["Z"]],
-    # incidenet energy
+    # incident energy 
     'E': [incident_energy],
     # cutoff energy - if E < Ec, particle stops
     'Ec': [ion["Ec"]],
@@ -230,7 +230,7 @@ geometry_1D = {
     'length_unit': 'ANGSTROM',
     # used to correct nonlocal stopping for known compound discrpancies
     'electronic_stopping_correction_factors': [1.0, 1.0, 1.0],
-    # thickness of each layer in order from top (x=0) to bottom
+    # thickness of each layer in order from top (x=0) to bottom 
     'layer_thicknesses': layer_thicknesses,
     # number densitiy of each layer in order from top to bottom
     'densities': [
@@ -260,30 +260,26 @@ input_string = dumps(input_data).replace('\r', '')
 with  open('examples/input_file.toml', 'w') as input_file:
     input_file.write(input_string)
 
-branches_to_test = ['dev', 'experimental_recoil_generation', 'improved_duff']
+if run_sim:
+    os.system(f'cargo run --release {mode} examples/input_file.toml')
 
-for branch in branches_to_test:
-    if run_sim:
-        os.system(f'git checkout {branch}')
-        os.system(f'cargo run --release {mode} examples/input_file.toml')
+# Read output files - ensure arrays are at least 2D for indexing
+sputtered = np.atleast_2d(np.genfromtxt('input_filesputtered.output', delimiter=','))
+reflected = np.atleast_2d(np.genfromtxt('input_filereflected.output', delimiter=','))
+implanted = np.atleast_2d(np.genfromtxt('input_filedeposited.output', delimiter=','))
 
-    # Read output files - ensure arrays are at least 2D for indexing
-    sputtered = np.atleast_2d(np.genfromtxt('input_filesputtered.output', delimiter=','))
-    reflected = np.atleast_2d(np.genfromtxt('input_filereflected.output', delimiter=','))
-    implanted = np.atleast_2d(np.genfromtxt('input_filedeposited.output', delimiter=','))
+print('H on B-TiB2-Ti')
+print(f'R_N, R_E: {np.size(reflected[:, 0])/number_ions}, {np.sum(reflected[:, 2]/incident_energy/number_ions)}')
+print(f'Y: {np.size(sputtered[:, 0])/number_ions} [at./ion]')
+print()
+print('H on B (default settings)')
+print(f'Y: {sputtering_yield(hydrogen, boron, incident_energy, angle, 10000)} [at./ion]')
+print(f'R_N, R_E: {reflection_coefficient(hydrogen, boron, incident_energy, angle, 10000)}')
 
-    print('H on B-TiB2-Ti')
-    print(f'R_N, R_E: {np.size(reflected[:, 0])/number_ions}, {np.sum(reflected[:, 2]/incident_energy/number_ions)}')
-    print(f'Y: {np.size(sputtered[:, 0])/number_ions} [at./ion]')
-    print()
-    print('H on B (default settings)')
-    print(f'Y: {sputtering_yield(hydrogen, boron, incident_energy, angle, 10000)} [at./ion]')
-    print(f'R_N, R_E: {reflection_coefficient(hydrogen, boron, incident_energy, angle, 10000)}')
-
-    x = implanted[:, 2]
-    num_bins=100
-    bins = np.linspace(0.0, 500.0, num_bins)
-    plt.hist(x, bins=bins, histtype='step', label=branch)
+x = implanted[:, 2]
+num_bins=100
+bins = np.linspace(0.0, 500.0, num_bins)
+plt.hist(x, bins=bins, histtype='step')
 if mode == '1D':
     plt.plot([layer_thicknesses[0], layer_thicknesses[0]], [0.0, number_ions], color='gray')
     plt.plot([layer_thicknesses[0] + layer_thicknesses[1], layer_thicknesses[0] + layer_thicknesses[1]], [0.0, number_ions], linestyle='--', color='gray')

--- a/examples/test_cube.py
+++ b/examples/test_cube.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.dirname(__file__)+'/../scripts')
 sys.path.append('scripts')
 from materials import *
 from rustbca import *
+from itertools import *
 
 #This function simply contains an entire input file as a multi-line f-string to modify some inputs.
 def run(energy, index, num_samples=10000, run_sim=True, a=1000, x0=0, y0=500, z0=500, ux=0.999, uy=0.01, uz=0.00, track_trajectories=False):
@@ -115,7 +116,7 @@ def main():
     run_sim = True
     track_trajectories = False
     a = 1000
-    num_samples = 10000
+    num_samples = 100000
     num_angles = 10
     energy = 200
     angles = np.linspace(0.0, 89.9, num_angles)
@@ -136,6 +137,13 @@ def main():
     R_y_minus = np.zeros(num_angles)
     R_z_minus = np.zeros(num_angles)
 
+    range_x = np.zeros(num_angles)
+    range_y = np.zeros(num_angles)
+    range_z = np.zeros(num_angles)
+    range_x_minus = np.zeros(num_angles)
+    range_y_minus = np.zeros(num_angles)
+    range_z_minus = np.zeros(num_angles)
+
     sim_index = 0
     impl_index = num_angles*3//4
     bins = np.linspace(0, 500, 100)
@@ -148,44 +156,92 @@ def main():
         if angle_index == impl_index: plt.hist(implanted[:, 2], histtype='step', bins=bins, density=False, label='x')
         sputtering_yields_x[angle_index] = Y
         R_x[angle_index] = R
+        range_x[angle_index] = np.mean(implanted[:, 2])
 
         R, Y, reflected, sputtered, implanted = run(energy, sim_index, num_samples, track_trajectories=track_trajectories, run_sim=run_sim, x0=a, ux=-np.cos(angle*np.pi/180.), uy=np.sin(angle*np.pi/180.)/np.sqrt(2), uz=np.sin(angle*np.pi/180.)/np.sqrt(2))
         sim_index += 1
         if angle_index == impl_index: plt.hist(a - implanted[:, 2], histtype='step', bins=bins, density=False, label='-x')
         sputtering_yields_x_minus[angle_index] = Y
         R_x_minus[angle_index] = R
+        range_x_minus[angle_index] = a - np.mean(implanted[:, 2])
 
         R, Y, reflected, sputtered, implanted = run(energy, sim_index, num_samples, track_trajectories=track_trajectories, run_sim=run_sim, x0=a/2., y0=a/2., z0=a, ux=np.sin(angle*np.pi/180.)/np.sqrt(2), uy=np.sin(angle*np.pi/180.)/np.sqrt(2), uz=-np.cos(angle*np.pi/180.))
         sim_index += 1
         if angle_index == impl_index: plt.hist(a - implanted[:, 4], histtype='step', bins=bins, density=False, label='-z')
-
         sputtering_yields_z_minus[angle_index] = Y
         R_z_minus[angle_index] = R
+        range_z_minus[angle_index] = a - np.mean(implanted[:, 4])
 
         R, Y, reflected, sputtered, implanted = run(energy, sim_index, num_samples, track_trajectories=track_trajectories, run_sim=run_sim, x0=a/2., y0=a/2., z0=0.0, ux=np.sin(angle*np.pi/180.)/np.sqrt(2), uy=np.sin(angle*np.pi/180.)/np.sqrt(2), uz=np.cos(angle*np.pi/180.))
         sim_index += 1
         if angle_index == impl_index: plt.hist(implanted[:, 4], histtype='step', bins=bins, density=False, label='z')
-
         sputtering_yields_z[angle_index] = Y
         R_z[angle_index] = R
+        range_z[angle_index] = np.mean(implanted[:, 4])
 
         R, Y, reflected, sputtered, implanted = run(energy, sim_index, num_samples, track_trajectories=track_trajectories, run_sim=run_sim, x0=a/2., y0=0.0, z0=a/2., ux=np.sin(angle*np.pi/180.)/np.sqrt(2), uz=np.sin(angle*np.pi/180.)/np.sqrt(2), uy=np.cos(angle*np.pi/180.))
         sim_index += 1
         if angle_index == impl_index: plt.hist(implanted[:, 3], histtype='step', bins=bins, density=False, label='y')
-
         sputtering_yields_y[angle_index] = Y
         R_y[angle_index] = R
+        range_y[angle_index] = np.mean(implanted[:, 3])
 
         R, Y, reflected, sputtered, implanted = run(energy, sim_index, num_samples, track_trajectories=track_trajectories, run_sim=run_sim, x0=a/2., y0=a, z0=a/2., ux=np.sin(angle*np.pi/180.)/np.sqrt(2), uz=np.sin(angle*np.pi/180.)/np.sqrt(2), uy=-np.cos(angle*np.pi/180.))
         sim_index += 1
         if angle_index == impl_index: plt.hist(a - implanted[:, 3], histtype='step', bins=bins, density=False, label='-y')
-
         sputtering_yields_y_minus[angle_index] = Y
         R_y_minus[angle_index] = R
+        range_y_minus[angle_index] = a - np.mean(implanted[:, 3])
 
     plt.figure(1)
     plt.title('Implantation')
     plt.legend()
+
+    yields = [
+        sputtering_yields_x,
+        sputtering_yields_y,
+        sputtering_yields_z,
+        sputtering_yields_x_minus,
+        sputtering_yields_y_minus,
+        sputtering_yields_z_minus
+    ]
+
+    # All sputtering yields for all directions should be close (3*sigma). This compares every pair
+    for Y1 in yields:
+        for Y2 in yields:
+            np.testing.assert_allclose(Y1, Y2, atol=3./np.sqrt(num_samples))
+
+    coeffs = [
+        R_x,
+        R_y,
+        R_z,
+        R_x_minus,
+        R_y_minus,
+        R_z_minus
+    ]
+
+    # All reflection coefficients for all directions should be close (3*sigma). This compares every pair
+    for R1 in coeffs:
+        assert(R1[-1] > 0.99) # R ~ 1 at 89.9 degrees
+        for R2 in coeffs:
+            np.testing.assert_allclose(R1, R2, atol=3./np.sqrt(num_samples))
+
+    ranges = [
+        range_x,
+        range_y,
+        range_z,
+        range_x_minus,
+        range_y_minus,
+        range_z_minus,
+    ]
+
+    for range1 in ranges:
+        for range2 in ranges: # since R ~ 1 at the highest two angles, there's too much variance in ranges
+            np.testing.assert_allclose(range1[:-2], range2[:-2], rtol=0.05)
+
+    breakpoint()
+
+    # All ranges 
 
     if do_plots:
         plt.figure(2)
@@ -209,11 +265,17 @@ def main():
         plt.legend()
 
         plt.show()
+        plt.savefig('test_cube.png')
+        plt.clf()
 
     if track_trajectories and do_plots:
         do_trajectory_plot('cube_19', boundary=[[0.0, 0.0], [0.0, a], [a, a], [a, 0.0], [0.0, 0.0]])
-
+        plt.savefig('test_cube_traj_1.png')
+        plt.clf()
+        
         do_trajectory_plot('cube_20', boundary=[[0.0, 0.0], [0.0, a], [a, a], [a, 0.0], [0.0, 0.0]])
+        plt.savefig('test_cube_traj_2.png')
+        plt.clf()
 
 if __name__ == '__main__':
     main()

--- a/examples/test_cube.py
+++ b/examples/test_cube.py
@@ -116,7 +116,7 @@ def main():
     run_sim = True
     track_trajectories = False
     a = 1000
-    num_samples = 100000
+    num_samples = 10000
     num_angles = 10
     energy = 200
     angles = np.linspace(0.0, 89.9, num_angles)

--- a/examples/test_cube.py
+++ b/examples/test_cube.py
@@ -239,10 +239,6 @@ def main():
         for range2 in ranges: # since R ~ 1 at the highest two angles, there's too much variance in ranges
             np.testing.assert_allclose(range1[:-2], range2[:-2], rtol=0.05)
 
-    breakpoint()
-
-    # All ranges 
-
     if do_plots:
         plt.figure(2)
         plt.title('Sputtering')

--- a/examples/test_cube.py
+++ b/examples/test_cube.py
@@ -114,7 +114,7 @@ def run(energy, index, num_samples=10000, run_sim=True, a=1000, x0=0, y0=500, z0
 def main():
     do_plots = False
     run_sim = True
-    track_trajectories = Falsehttps://github.com/lcpp-org/RustBCA/pull/315
+    track_trajectories = False
     a = 1000
     num_samples = 100000
     num_angles = 10

--- a/examples/test_cube.py
+++ b/examples/test_cube.py
@@ -112,9 +112,9 @@ def run(energy, index, num_samples=10000, run_sim=True, a=1000, x0=0, y0=500, z0
     return num_reflected/num_samples, num_sputtered/num_samples, reflected_list, sputtered_list, implanted_list
 
 def main():
-    do_plots = True
+    do_plots = False
     run_sim = True
-    track_trajectories = False
+    track_trajectories = Falsehttps://github.com/lcpp-org/RustBCA/pull/315
     a = 1000
     num_samples = 100000
     num_angles = 10

--- a/examples/test_rustbca.py
+++ b/examples/test_rustbca.py
@@ -77,20 +77,20 @@ def main():
     Y = sputtering_yield(ion, target, energy, angle, num_samples)
 
     print(f'Sputtering yield for {ion["symbol"]} on {target["symbol"]} at {energy} eV is {Y} at/ion. Yamamura predicts { np.round(yamamura(ion, target, energy),3)} at/ion.')
-    np.testing.assert_approx_equal(Y, 0.045)
+    np.testing.assert_approx_equal(Y, 0.044)
 
 
     R_N, R_E = reflection_coefficient(ion, target, energy, angle, num_samples)
     print(f'Particle reflection coefficient for {ion["symbol"]} on {target["symbol"]} at {energy} eV is {R_N}. Thomas predicts {np.round(thomas_reflection(ion, target, energy), 3)}.')
     print(f'Energy reflection coefficient for {ion["symbol"]} on {target["symbol"]} at {energy} eV is {R_E}')
-    np.testing.assert_approx_equal(R_N, 0.435)
-    np.testing.assert_approx_equal(R_E, 0.23222361140889344)
+    np.testing.assert_approx_equal(R_N, 0.426)
+    np.testing.assert_approx_equal(R_E, 0.23367711096087937)
 
     R_N, R_E = compound_reflection_coefficient(ion, [target, ion], [target['n'], 0.1*target['n']], energy, angle, num_samples)
     print(f'Particle reflection coefficient for {ion["symbol"]} on {ion["symbol"]}x{target["symbol"]} where x=0.1 at {energy} eV is {R_N}. Thomas predicts {np.round(thomas_reflection(ion, target, energy), 3)}.')
     print(f'Energy reflection coefficient for {ion["symbol"]}x{target["symbol"]} where x=0.1 at {energy} eV is {R_E}')
-    np.testing.assert_approx_equal(R_N, 0.421)
-    np.testing.assert_approx_equal(R_E, 0.22787000234654273)
+    np.testing.assert_approx_equal(R_N, 0.424)
+    np.testing.assert_approx_equal(R_E, 0.22840032456593984)
 
 
     vx0 = 1e5
@@ -215,7 +215,7 @@ def main():
     plt.plot([50.0, 50.0], [0.0, np.max(heights)*1.1])
     plt.gca().set_ylim([0.0, np.max(heights)*1.1])
 
-    np.testing.assert_approx_equal(np.mean(x), 12.179891077431188)
+    np.testing.assert_approx_equal(np.mean(x), 12.957009857301925)
 
     number_ions = 10000
 
@@ -285,8 +285,8 @@ def main():
     print(f'RustBCA R: {len(reflected[:, 0])/number_ions} Thomas R: {thomas}')
     print(f'Time per ion: {delta_time/number_ions} s/{ion["symbol"]}')
 
-    np.testing.assert_approx_equal(len(sputtered[:, 0])/number_ions, 0.027)
-    np.testing.assert_approx_equal(len(reflected[:, 0])/number_ions, 0.5089)
+    np.testing.assert_approx_equal(len(sputtered[:, 0])/number_ions, 0.0267)
+    np.testing.assert_approx_equal(len(reflected[:, 0])/number_ions, 0.5129)
 
     plt.figure()
     plt.plot(incident_index)
@@ -294,7 +294,11 @@ def main():
     plt.ylabel('Particle index')
     plt.legend(['Incident', 'Indicies'])
 
-    plt.show()
+    show_plot = False
+    if show_plot:
+        plt.show()
+    else:
+        plt.savefig('test_rustbca.png')
 
 if __name__ == '__main__':
     main()

--- a/examples/test_rustbca.py
+++ b/examples/test_rustbca.py
@@ -27,15 +27,21 @@ def main():
     uz = 0.0
 
     print(f'Before rotation: ({ux}, {uy}, {uz})')
-    ux, uy, uz = rotate_given_surface_normal_py(nx, ny, nz, ux, uy, uz)
-    print(f'After rotation: ({ux}, {uy}, {uz})')
-    ux, uy, uz = rotate_back_py(nx, ny, nz, ux, uy, uz)
-    print(f'After rotation back: ({ux}, {uy}, {uz})')
+    ux1, uy1, uz1 = rotate_given_surface_normal_py(nx, ny, nz, ux, uy, uz)
+    print(f'After rotation: ({ux1}, {uy1}, {uz1})')
+    ux2, uy2, uz2 = rotate_back_py(nx, ny, nz, ux1, uy1, uz1)
+    print(f'After rotation back: ({ux2}, {uy2}, {uz2})')
 
     #After rotating and rotating back, effect should be where you started (minus fp error)
-    assert(abs(ux - 1.0) < 1e-6)
-    assert(abs(uy) < 1e-6)
-    assert(abs(uz) < 1e-6)
+    np.testing.assert_allclose(ux2 - 1.0, 0.0)
+    np.testing.assert_allclose(uy2, 0.0, atol=1e-9)
+    np.testing.assert_allclose(uz2, 0.0, atol=1e-9)
+
+
+    #If ux is (1, 0, 0), this transform should just swap u with -n
+    #np.testing.assert_approx_equal(ux1, -nx)
+    #np.testing.assert_approx_equal(uy1, -ny)
+    #np.testing.assert_approx_equal(uz1, -nz)
 
     #test vectorized rotation to and from RustBCA coordinates
 
@@ -46,21 +52,46 @@ def main():
     ny = [-np.sqrt(2)/2]*num_rot_test
     nz = [0.0]*num_rot_test
 
+    np.random.seed(0)
+    nx = np.random.uniform(-1.0, 0.0, num_rot_test)
+    ny = np.random.uniform(-1.0, 1.0, num_rot_test)
+    nz = np.random.uniform(-1.0, 1.0, num_rot_test)
+    mags = np.sqrt(nx*nx + ny*ny + nz*nz)
+    nx /= mags
+    ny /= mags
+    nz /= mags
+
     #ux, uy, uz is the particle direction (simulation coordinates)
-    ux = [1.0]*num_rot_test
-    uy = [0.0]*num_rot_test
-    uz = [0.0]*num_rot_test
+    np.random.seed(0)
+    ux = np.random.uniform(-1.0, 1.0, num_rot_test)
+    uy = np.random.uniform(-1.0, 1.0, num_rot_test)
+    uz = np.random.uniform(-1.0, 1.0, num_rot_test)
+    mags = np.sqrt(ux*ux + uy*uy + uz*uz)
+    ux /= mags
+    uy /= mags
+    uz /= mags
 
     start = time.time()
-    ux, uy, uz = rotate_given_surface_normal_vec_py(nx, ny, nz, ux, uy, uz)
-    ux, uy, uz = rotate_back_vec_py(nx, ny, nz, ux, uy, uz)
+    ux1, uy1, uz1 = rotate_given_surface_normal_vec_py(nx, ny, nz, ux, uy, uz)
+    ux2, uy2, uz2 = rotate_back_vec_py(nx, ny, nz, ux1, uy1, uz1)
     stop = time.time()
     print(f'Time to rotate: {(stop - start)/num_rot_test} sec/vector')
 
+    # ensure that R n = (-1, 0, 0)
+    nx1, ny1, nz1 = rotate_given_surface_normal_vec_py(nx, ny, nz, nx, ny, nz)
+    np.testing.assert_allclose(nx1, -1.0)
+    np.testing.assert_allclose(ny1, 0.0, atol=1e-12)
+    np.testing.assert_allclose(nz1, 0.0, atol=1e-12)
+
+    # ensure angle between n and u remains constant
+    cosine = nx*ux + ny*uy + nz*uz
+    cosine1 = -np.array(ux1) # here n becomes (-1, 0, 0)
+    np.testing.assert_allclose(cosine, cosine1)
+
     #After rotating and rotating back, effect should be where you started (minus fp error)
-    assert(abs(ux[0] - 1.0) < 1e-6)
-    assert(abs(uy[0]) < 1e-6)
-    assert(abs(uz[0]) < 1e-6)
+    np.testing.assert_allclose(ux, ux2)
+    np.testing.assert_allclose(uy, uy2)
+    np.testing.assert_allclose(uz, uz2)
 
     #scripts/materials.py has a number of potential ions and targets
     ion = helium
@@ -92,7 +123,6 @@ def main():
     np.testing.assert_approx_equal(R_N, 0.424)
     np.testing.assert_approx_equal(R_E, 0.22840032456593984)
 
-
     vx0 = 1e5
     vy0 = 1e5
     vz0 = 0.0
@@ -102,7 +132,7 @@ def main():
     print(f'(vx, vy, vz) after reflection: ({vx1}, {vy1}, {vz1})')
 
     #For smooth distributions and good statistics, you should use at least 10k ions
-    number_ions = 10000
+    number_ions = 100000
 
     #1 keV is above the He on W sputtering threshold of ~150 eV
     energies_eV = 1000.0*np.ones(number_ions)
@@ -171,6 +201,8 @@ def main():
     # check that reflection/sputtering are reasonable
     assert(0.01 < len(sputtered[:, 0])/number_ions < 0.03)
     assert(0.4 < len(reflected[:, 0])/number_ions < 0.6)
+
+    number_ions = 10000
 
     #Next up is the layered target version. I'll add a 50 Angstrom layer of W-H to the top of the target.
 

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -347,26 +347,6 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
     }
 }
 
-/// This function finds an orthonormal basis from a unit vector n
-/// it should avoid all numerical / consistency issues
-/// Duff et al., JCGT 2017
-/// http://jcgt.org/published/0006/01/01/
-fn duff_orthonormal_basis(n: Vector) -> (Vector, Vector) {
-    if n.z < 0. {
-        let a = 1.0 / (1.0 - n.z);
-        let b = n.x * n.y * a;
-        let b1 = Vector::new(1.0 - n.x*n.x*a, -b, n.x);
-        let b2 = Vector::new(b, n.y * n.y*a- 1.0, -n.y);
-        (b1, b2)
-    } else {
-        let a = 1.0 / (1.0 + n.z);
-        let b = -n.x * n.y * a;
-        let b1 = Vector::new(1.0 - n.x*n.x*a, b, -n.x);
-        let b2 = Vector::new(b, 1.0 - n.y*n.y*a, -n.y);
-        (b1, b2)
-    }
-}
-
 /// For a particle in a material, and for a particular binary collision geometry, choose a species for the collision partner.
 pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, material: &material::Material<T>, binary_collision_geometry: &BinaryCollisionGeometry, options: &Options, rng: &mut ChaCha8Rng) -> (usize, particle::Particle) {
     let x = particle_1.pos.x;
@@ -408,10 +388,10 @@ pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, ma
     } else {
         z + mfp*cosz + impact_parameter*(cosx*cosphi + cosy*sinphi)
     };*/
-    let (e1, e2) = duff_orthonormal_basis(particle_1.dir);
-    let x_recoil = x + impact_parameter*(e1.x*cosphi + e2.x*sinphi);
-    let y_recoil = y + impact_parameter*(e1.y*cosphi + e2.y*sinphi);
-    let z_recoil = z + impact_parameter*(e1.z*cosphi + e2.z*sinphi);
+    let (e1, e2) = math::duff_orthonormal_basis(particle_1.dir);
+    let x_recoil = x + mfp*cosx + impact_parameter*(e1.x*cosphi + e2.x*sinphi);
+    let y_recoil = y + mfp*cosy + impact_parameter*(e1.y*cosphi + e2.y*sinphi);
+    let z_recoil = z + mfp*cosz + impact_parameter*(e1.z*cosphi + e2.z*sinphi);
 
     //Choose recoil Z, M
     let (species_index, Z_recoil, M_recoil, Ec_recoil, Es_recoil, Ed_recoil, interaction_index) = material.choose(x_recoil, y_recoil, z_recoil, rng);

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -389,9 +389,9 @@ pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, ma
         z + mfp*cosz + impact_parameter*(cosx*cosphi + cosy*sinphi)
     };*/
     let (e1, e2) = math::duff_orthonormal_basis(particle_1.dir);
-    let x_recoil = x + mfp*cosx + impact_parameter*(e1.x*cosphi + e2.x*sinphi);
-    let y_recoil = y + mfp*cosy + impact_parameter*(e1.y*cosphi + e2.y*sinphi);
-    let z_recoil = z + mfp*cosz + impact_parameter*(e1.z*cosphi + e2.z*sinphi);
+    let x_recoil = x + mfp*cosx - impact_parameter*(e1.x*cosphi + e2.x*sinphi);
+    let y_recoil = y + mfp*cosy - impact_parameter*(e1.y*cosphi + e2.y*sinphi);
+    let z_recoil = z + mfp*cosz - impact_parameter*(e1.z*cosphi + e2.z*sinphi);
 
     //Choose recoil Z, M
     let (species_index, Z_recoil, M_recoil, Ec_recoil, Es_recoil, Ed_recoil, interaction_index) = material.choose(x_recoil, y_recoil, z_recoil, rng);

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -365,29 +365,6 @@ pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, ma
     let sinx: f64 = (1. - cosx*cosx).sqrt();
     let cosphi: f64 = phi_azimuthal.cos();
 
-    // These formulas find the recoil one mfp away at an impact parameter p at angle phi
-    // To resolve the singularity, a different set of rotations is used when cosx == -1
-    // Because of this, the recoil location is not consistent between the two formulas at a given phi
-    // Since phi is sampled uniformly from (0, 2pi), this does not matter
-    // However, if a crystalline structure is ever added, this needs to be considered
-    /*
-    let x_recoil = if cosx > -1. + 1e-6 {
-        x + mfp*cosx - impact_parameter*(cosz*sinphi + cosy*cosphi)
-    } else {
-        x + mfp*cosx - impact_parameter*((1. + cosz - cosx*cosx)*cosphi - cosx*cosy*sinphi)/(1. + cosz)
-    };
-
-    let y_recoil = if cosx > -1. + 1e-6 {
-        y + mfp*cosy + impact_parameter*((1. + cosx - cosy*cosy)*cosphi - cosy*cosz*sinphi)/(1. + cosx)
-    } else {
-        y + mfp*cosy + impact_parameter*((1. + cosz - cosy*cosy)*sinphi - cosx*cosy*cosphi)/(1. + cosz)
-    };
-
-    let z_recoil = if cosx > -1. + 1e-6 {
-        z + mfp*cosz + impact_parameter*((1. + cosx - cosz*cosz)*sinphi - cosy*cosz*cosphi)/(1. + cosx)
-    } else {
-        z + mfp*cosz + impact_parameter*(cosx*cosphi + cosy*sinphi)
-    };*/
     let (e1, e2) = math::duff_orthonormal_basis(particle_1.dir);
     let x_recoil = x + mfp*cosx - impact_parameter*(e1.x*cosphi + e2.x*sinphi);
     let y_recoil = y + mfp*cosy - impact_parameter*(e1.y*cosphi + e2.y*sinphi);

--- a/src/bca.rs
+++ b/src/bca.rs
@@ -347,6 +347,26 @@ pub fn determine_mfp_phi_impact_parameter<T: Geometry>(particle_1: &mut particle
     }
 }
 
+/// This function finds an orthonormal basis from a unit vector n
+/// it should avoid all numerical / consistency issues
+/// Duff et al., JCGT 2017
+/// http://jcgt.org/published/0006/01/01/
+fn duff_orthonormal_basis(n: Vector) -> (Vector, Vector) {
+    if n.z < 0. {
+        let a = 1.0 / (1.0 - n.z);
+        let b = n.x * n.y * a;
+        let b1 = Vector::new(1.0 - n.x*n.x*a, -b, n.x);
+        let b2 = Vector::new(b, n.y * n.y*a- 1.0, -n.y);
+        (b1, b2)
+    } else {
+        let a = 1.0 / (1.0 + n.z);
+        let b = -n.x * n.y * a;
+        let b1 = Vector::new(1.0 - n.x*n.x*a, b, -n.x);
+        let b2 = Vector::new(b, 1.0 - n.y*n.y*a, -n.y);
+        (b1, b2)
+    }
+}
+
 /// For a particle in a material, and for a particular binary collision geometry, choose a species for the collision partner.
 pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, material: &material::Material<T>, binary_collision_geometry: &BinaryCollisionGeometry, options: &Options, rng: &mut ChaCha8Rng) -> (usize, particle::Particle) {
     let x = particle_1.pos.x;
@@ -370,23 +390,28 @@ pub fn choose_collision_partner<T: Geometry>(particle_1: &particle::Particle, ma
     // Because of this, the recoil location is not consistent between the two formulas at a given phi
     // Since phi is sampled uniformly from (0, 2pi), this does not matter
     // However, if a crystalline structure is ever added, this needs to be considered
-    let x_recoil = if cosx > -1. {
+    /*
+    let x_recoil = if cosx > -1. + 1e-6 {
         x + mfp*cosx - impact_parameter*(cosz*sinphi + cosy*cosphi)
     } else {
         x + mfp*cosx - impact_parameter*((1. + cosz - cosx*cosx)*cosphi - cosx*cosy*sinphi)/(1. + cosz)
     };
 
-    let y_recoil = if cosx > -1. {
+    let y_recoil = if cosx > -1. + 1e-6 {
         y + mfp*cosy + impact_parameter*((1. + cosx - cosy*cosy)*cosphi - cosy*cosz*sinphi)/(1. + cosx)
     } else {
         y + mfp*cosy + impact_parameter*((1. + cosz - cosy*cosy)*sinphi - cosx*cosy*cosphi)/(1. + cosz)
     };
 
-    let z_recoil = if cosx > -1. {
+    let z_recoil = if cosx > -1. + 1e-6 {
         z + mfp*cosz + impact_parameter*((1. + cosx - cosz*cosz)*sinphi - cosy*cosz*cosphi)/(1. + cosx)
     } else {
         z + mfp*cosz + impact_parameter*(cosx*cosphi + cosy*sinphi)
-    };
+    };*/
+    let (e1, e2) = duff_orthonormal_basis(particle_1.dir);
+    let x_recoil = x + impact_parameter*(e1.x*cosphi + e2.x*sinphi);
+    let y_recoil = y + impact_parameter*(e1.y*cosphi + e2.y*sinphi);
+    let z_recoil = z + impact_parameter*(e1.z*cosphi + e2.z*sinphi);
 
     //Choose recoil Z, M
     let (species_index, Z_recoil, M_recoil, Ec_recoil, Es_recoil, Ed_recoil, interaction_index) = material.choose(x_recoil, y_recoil, z_recoil, rng);

--- a/src/input.rs
+++ b/src/input.rs
@@ -427,11 +427,11 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
     }
 
     for Ed_ in &material.Ed {
-        assert!(*Ed_ > 0.0, "Input Error: Ed cannot be less than zero.")
+        assert!(*Ed_ > 0.0, "Input Error: Ed = {}; Ed cannot be less than zero.", Ed_);
     }
 
     for Eb_ in &material.Eb {
-        assert!(*Eb_ > 0.0, "Input Error: Eb cannot be less than zero.")
+        assert!(*Eb_ > 0.0, "Input Error: Eb = {}; Eb cannot be less than zero.", Eb_);
     }
 
     //Check that incompatible options are not on simultaneously

--- a/src/input.rs
+++ b/src/input.rs
@@ -665,27 +665,27 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
                             y: match y {
                                 Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
                                 Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
-                                Distributions::POINT(x) => x*length_unit,
+                                Distributions::POINT(y) => y*length_unit,
                             },
                             z: match z {
                                 Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
                                 Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
-                                Distributions::POINT(x) => x*length_unit,
+                                Distributions::POINT(z) => z*length_unit,
                             },
                             ux: match cosx {
                                 Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
                                 Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
-                                Distributions::POINT(x) => x*length_unit
+                                Distributions::POINT(ux) => ux
                             },
                             uy: match cosy {
                                 Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
                                 Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
-                                Distributions::POINT(x) => x*length_unit,
+                                Distributions::POINT(uy) => uy,
                             },
                             uz: match cosz {
                                 Distributions::NORMAL{mean, std} => {let normal = Normal::new(mean, std).unwrap(); normal.sample(&mut rng)*length_unit},
                                 Distributions::UNIFORM{min, max} => {let uniform = Uniform::new(min, max).unwrap();  uniform.sample(&mut rng)*length_unit},
-                                Distributions::POINT(x) => x*length_unit,
+                                Distributions::POINT(uz) => uz,
                             },
                             interaction_index,
                             tag: 0,

--- a/src/input.rs
+++ b/src/input.rs
@@ -426,6 +426,14 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
         material.Ed = vec![material.Ed[0]; material.m.len()];
     }
 
+    for Ed_ in &material.Ed {
+        assert!(*Ed_ > 0.0, "Input Error: Ed cannot be less than zero.")
+    }
+
+    for Eb_ in &material.Eb {
+        assert!(*Eb_ > 0.0, "Input Error: Eb cannot be less than zero.")
+    }
+
     //Check that incompatible options are not on simultaneously
     if options.high_energy_free_flight_paths {
         assert!(options.electronic_stopping_mode == ElectronicStoppingMode::INTERPOLATED,

--- a/src/input.rs
+++ b/src/input.rs
@@ -427,11 +427,11 @@ where <T as Geometry>::InputFileFormat: Deserialize<'static> + 'static {
     }
 
     for Ed_ in &material.Ed {
-        assert!(*Ed_ > 0.0, "Input Error: Ed = {}; Ed cannot be less than zero.", Ed_);
+        assert!(*Ed_ >= 0.0, "Input Error: Ed = {}; Ed cannot be less than zero.", Ed_);
     }
 
     for Eb_ in &material.Eb {
-        assert!(*Eb_ > 0.0, "Input Error: Eb = {}; Eb cannot be less than zero.", Eb_);
+        assert!(*Eb_ >= 0.0, "Input Error: Eb = {}; Eb cannot be less than zero.", Eb_);
     }
 
     //Check that incompatible options are not on simultaneously

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1563,6 +1563,7 @@ pub fn simple_compound_bca(x: f64, y: f64, z: f64, ux: f64, uy: f64, uz: f64, E1
 pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mut f64, uy: &mut f64, uz: &mut f64) {
 
     let direction = Vector3::new(*ux, *uy, *uz);
+    let n = Vector3::new(nx, ny, nz);
 
     //Rotation to local RustBCA coordinates from global
     //Here's how this works: a rotation matrix is found that maps the rustbca
@@ -1579,7 +1580,12 @@ pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mu
         Rotation3::from_axis_angle(&Vector3::y_axis(), PI).into()
     };
 
-    let incident = rotation_matrix*direction;
+    let (b1, b2) = duff_orthonormal_basis(Vector::new(-nx, -ny, -nz));
+    let e1 = Vector3::new(b1.x, b1.y, b1.z);
+    let e2 = Vector3::new(b2.x, b2.y, b2.z);
+    let rotation_matrix_duff = Matrix3::from_columns(&[-n, e1, e2]);
+
+    let incident = rotation_matrix_duff*direction;
 
     *ux = incident.x;
     *uy = incident.y;
@@ -1661,6 +1667,7 @@ pub fn rotate_given_surface_normal_vec_py(nx: Vec<f64>, ny: Vec<f64>, nz: Vec<f6
 pub extern "C" fn rotate_back(nx: f64, ny: f64, nz: f64, ux: &mut f64, uy: &mut f64, uz: &mut f64) {
 
     let direction = Vector3::new(*ux, *uy, *uz);
+    let n = Vector3::new(nx, ny, nz);
 
     //Rotation to local RustBCA coordinates from global
     //Here's how this works: a rotation matrix is found that maps the rustbca
@@ -1675,8 +1682,13 @@ pub extern "C" fn rotate_back(nx: f64, ny: f64, nz: f64, ux: &mut f64, uy: &mut 
         Rotation3::from_axis_angle(&Vector3::y_axis(), PI).into()
     };
 
+    let (b1, b2) = duff_orthonormal_basis(Vector::new(-nx, -ny, -nz));
+    let e1 = Vector3::new(b1.x, b1.y, b1.z);
+    let e2 = Vector3::new(b2.x, b2.y, b2.z);
+    let rotation_matrix_duff = Matrix3::from_columns(&[-n, e1, e2]);
+
     // Note: transpose of R == R^-1
-    let u = rotation_matrix.transpose()*direction;
+    let u = rotation_matrix_duff.transpose()*direction;
 
     *ux = u.x;
     *uy = u.y;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1568,20 +1568,19 @@ pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mu
     let (b1, b2) = duff_orthonormal_basis(Vector::new(-nx, -ny, -nz));
     let e1 = Vector3::new(b1.x, b1.y, b1.z);
     let e2 = Vector3::new(b2.x, b2.y, b2.z);
-    let rotation_matrix_duff = Matrix3::from_columns(&[-n, e1, e2]);
+    let rotation_matrix_duff = Matrix3::from_columns(&[-n, e1, e2]).transpose();
+    // Duff et al. provide a robust algorithm that constructs an orthonormal basis from n
+    // That basis is used to construct an R such that R ex = -n, R ey = e1, R ez = e2.
+    // The transpose of this matrix gives the matrix we want, R^T n = ex.
+    // That is, R maps the global normal vector onto the RustBCA normal vector.
+    // And thus R maps a global particle velocity into the RustBCA frame.
 
     let incident = rotation_matrix_duff*direction;
 
     *ux = incident.x;
     *uy = incident.y;
     *uz = incident.z;
-    let mag = (ux.powi(2) + uy.powi(2) + uz.powi(2)).sqrt();
-
-    *ux /= mag;
-    *uy /= mag;
-    *uz /= mag;
 }
-
 
 
 #[cfg(all(feature = "python", feature = "parry3d"))]
@@ -1658,15 +1657,16 @@ pub extern "C" fn rotate_back(nx: f64, ny: f64, nz: f64, ux: &mut f64, uy: &mut 
     let e1 = Vector3::new(b1.x, b1.y, b1.z);
     let e2 = Vector3::new(b2.x, b2.y, b2.z);
     let rotation_matrix_duff = Matrix3::from_columns(&[-n, e1, e2]);
+    // Duff et al. provide a robust algorithm that constructs an orthonormal basis from n
+    // That basis is used to construct an R such that R ex = -n, R ey = e1, R ez = e2.
+    // This is the transpose of the matrix in rotate_given_surface_normal.
+    // Since, for rotation matrices, R^T = R^-1, this is the inverse transform.
 
     let incident = rotation_matrix_duff*direction;
 
-    // Note: transpose of R == R^-1
-    let u = rotation_matrix_duff.transpose()*direction;
-
-    *ux = u.x;
-    *uy = u.y;
-    *uz = u.z;
+    *ux = incident.x;
+    *uy = incident.y;
+    *uz = incident.z;
 }
 
 #[cfg(all(feature = "python", feature = "parry3d"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1565,21 +1565,6 @@ pub extern "C" fn rotate_given_surface_normal(nx: f64, ny: f64, nz: f64, ux: &mu
     let direction = Vector3::new(*ux, *uy, *uz);
     let n = Vector3::new(nx, ny, nz);
 
-    //Rotation to local RustBCA coordinates from global
-    //Here's how this works: a rotation matrix is found that maps the rustbca
-    //into-the-surface vector (1.0, 0.0, 0.0) onto the local into-the-surface vector (negative normal w.r.t. ray origin).
-    //That rotation is then applied to the particle direction, and can be undone later.
-    //Algorithm is from here:
-    //https://math.stackexchange.com/questions/180418/calculate-rotation-matrix-to-align-vector-a-to-vector-b-in-3d/180436#180436
-
-    let rotation_matrix = if (1.0 - nx).abs() > 0.0 {
-        Matrix3::<f64>::new(1. + (-ny*ny - nz*nz)/(1. - nx), -ny, -nz, ny, -ny*ny/(1. - nx) + 1., -ny*nz/(1. - nx), nz, -ny*nz/(1. - nx), -nz*nz/(1. - nx) + 1.)
-    } else {
-        //If c == -1.0, the correct rotation should simply be a 180 degree rotation
-        //around a non-x axis; y is chosen arbitrarily
-        Rotation3::from_axis_angle(&Vector3::y_axis(), PI).into()
-    };
-
     let (b1, b2) = duff_orthonormal_basis(Vector::new(-nx, -ny, -nz));
     let e1 = Vector3::new(b1.x, b1.y, b1.z);
     let e2 = Vector3::new(b2.x, b2.y, b2.z);
@@ -1669,23 +1654,12 @@ pub extern "C" fn rotate_back(nx: f64, ny: f64, nz: f64, ux: &mut f64, uy: &mut 
     let direction = Vector3::new(*ux, *uy, *uz);
     let n = Vector3::new(nx, ny, nz);
 
-    //Rotation to local RustBCA coordinates from global
-    //Here's how this works: a rotation matrix is found that maps the rustbca
-    //into-the-surface vector (1.0, 0.0, 0.0) onto the local into-the-surface vector (negative normal w.r.t. ray origin).
-    //That rotation is then applied to the particle direction, and can be undone later.
-    //Algorithm is from here:
-    let rotation_matrix = if (1.0 - nx).abs() > 0.0 {
-        Matrix3::<f64>::new(1. + (-ny*ny - nz*nz)/(1. - nx), -ny, -nz, ny, -ny*ny/(1. - nx) + 1., -ny*nz/(1. - nx), nz, -ny*nz/(1. - nx), -nz*nz/(1. - nx) + 1.)
-    } else {
-        //If c == -1.0, the correct rotation should simply be a 180 degree rotation
-        //around a non-x axis; y is chosen arbitrarily
-        Rotation3::from_axis_angle(&Vector3::y_axis(), PI).into()
-    };
-
     let (b1, b2) = duff_orthonormal_basis(Vector::new(-nx, -ny, -nz));
     let e1 = Vector3::new(b1.x, b1.y, b1.z);
     let e2 = Vector3::new(b2.x, b2.y, b2.z);
     let rotation_matrix_duff = Matrix3::from_columns(&[-n, e1, e2]);
+
+    let incident = rotation_matrix_duff*direction;
 
     // Note: transpose of R == R^-1
     let u = rotation_matrix_duff.transpose()*direction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub mod enums;
 pub mod consts;
 pub mod structs;
 pub mod sphere;
+pub mod math;
 
 #[cfg(feature = "parry3d")]
 pub mod parry;
@@ -80,6 +81,7 @@ pub use crate::input::{Input2D, InputHomogeneous2D, Input1D, Input0D, Options, I
 pub use crate::output::{OutputUnits};
 pub use crate::geometry::{Geometry, GeometryElement, Mesh0D, Mesh1D, Mesh2D};
 pub use crate::sphere::{Sphere, SphereInput, InputSphere};
+pub use crate::math::*;
 
 #[cfg(feature = "parry3d")]
 pub use crate::parry::{ParryBall, ParryBallInput, InputParryBall, ParryTriMesh, ParryTriMeshInput, InputParryTriMesh};

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ pub mod consts;
 pub mod structs;
 pub mod sphere;
 pub mod physics;
+pub mod math;
 
 #[cfg(feature = "parry3d")]
 pub mod parry;
@@ -64,6 +65,7 @@ pub use crate::output::{OutputUnits};
 pub use crate::geometry::{Geometry, GeometryElement, Mesh0D, Mesh1D, Mesh2D, HomogeneousMesh2D};
 pub use crate::sphere::{Sphere, SphereInput, InputSphere};
 pub use crate::physics::{physics_loop};
+pub use crate::math::duff_orthonormal_basis;
 
 #[cfg(feature = "parry3d")]
 pub use crate::parry::{ParryBall, ParryBallInput, InputParryBall, ParryTriMesh, ParryTriMeshInput, InputParryTriMesh};

--- a/src/material.rs
+++ b/src/material.rs
@@ -298,7 +298,7 @@ impl <T: Geometry> Material<T> {
 
             let stopping_power = match electronic_stopping_mode {
                 //Biersack-Varelas Interpolation
-                ElectronicStoppingMode::INTERPOLATED => 1./(1./S_high + 1./(S_low*ck))
+                ElectronicStoppingMode::INTERPOLATED => 1./(1./S_high + 1./(S_low*ck)),
                 //Oen-Robinson
                 ElectronicStoppingMode::LOW_ENERGY_LOCAL => S_low*ck,
                 //Lindhard-Scharff

--- a/src/material.rs
+++ b/src/material.rs
@@ -298,7 +298,7 @@ impl <T: Geometry> Material<T> {
 
             let stopping_power = match electronic_stopping_mode {
                 //Biersack-Varelas Interpolation
-                ElectronicStoppingMode::INTERPOLATED => 1./(1./S_high + 1./S_low)*ck,
+                ElectronicStoppingMode::INTERPOLATED => 1./(1./S_high + 1./(S_low*ck))
                 //Oen-Robinson
                 ElectronicStoppingMode::LOW_ENERGY_LOCAL => S_low*ck,
                 //Lindhard-Scharff

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,20 @@
+use super::*;
+/// This function finds an orthonormal basis from a unit vector n
+/// it should avoid all numerical / consistency issues
+/// Duff et al., JCGT 2017
+/// http://jcgt.org/published/0006/01/01/
+pub fn duff_orthonormal_basis(n: Vector) -> (Vector, Vector) {
+    if n.z < 0. {
+        let a = 1.0 / (1.0 - n.z);
+        let b = n.x * n.y * a;
+        let b1 = Vector::new(1.0 - n.x*n.x*a, -b, n.x);
+        let b2 = Vector::new(b, n.y * n.y*a- 1.0, -n.y);
+        (b1, b2)
+    } else {
+        let a = 1.0 / (1.0 + n.z);
+        let b = -n.x * n.y * a;
+        let b1 = Vector::new(1.0 - n.x*n.x*a, b, -n.x);
+        let b2 = Vector::new(b, 1.0 - n.y*n.y*a, -n.y);
+        (b1, b2)
+    }
+}

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -236,8 +236,8 @@ impl Particle {
         let cosx: f64 = self.dir.x;
         let cosy: f64 = self.dir.y;
         let cosz: f64 = self.dir.z;
-        let cosphi: f64 = (phi + PI).cos();
-        let sinphi: f64 = (phi + PI).sin();
+        let cosphi: f64 = (phi - PI).cos();
+        let sinphi: f64 = (phi - PI).sin();
 
         let cpsi: f64 = psi.cos();
         let spsi: f64 = psi.sin();

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -266,7 +266,7 @@ impl Particle {
         };
         */
 
-        let (e1, e2) = duff_orthonormal_basis(self.dir);
+        let (e1, e2) = math::duff_orthonormal_basis(self.dir);
         let cosx_new = cpsi*cosx - spsi*(cosphi*e1.x + sinphi*e2.x);
         let cosy_new = cpsi*cosy - spsi*(cosphi*e1.y + sinphi*e2.y);
         let cosz_new = cpsi*cosz - spsi*(cosphi*e1.z + sinphi*e2.z);

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -246,6 +246,7 @@ impl Particle {
         // Because of this, the recoil location is not consistent between the two formulas at a given phi
         // Since phi is sampled uniformly from (0, 2pi), this does not matter
         // However, if a crystalline structure is ever added, this needs to be considered
+        /*
         let cosx_new = if cosx > -1. {
             cpsi*cosx - spsi*(cosz*sinphi + cosy*cosphi)
         } else {
@@ -263,6 +264,12 @@ impl Particle {
         } else {
             cpsi*cosz + spsi*(cosx*cosphi + cosy*sinphi)
         };
+        */
+
+        let (e1, e2) = duff_orthonormal_basis(self.dir);
+        let cosx_new = cpsi*cosx - spsi*(cosphi*e1.x + sinphi*e2.x);
+        let cosy_new = cpsi*cosy - spsi*(cosphi*e1.y + sinphi*e2.y);
+        let cosz_new = cpsi*cosz - spsi*(cosphi*e1.z + sinphi*e2.z);
 
         let dir_new = Vector {x: cosx_new, y: cosy_new, z: cosz_new};
 

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -236,7 +236,7 @@ impl Particle {
         let cosx: f64 = self.dir.x;
         let cosy: f64 = self.dir.y;
         let cosz: f64 = self.dir.z;
-        // minus sign here enforces particle deflection in opposite direction of recoil location
+        // PI rotation here enforces particle deflection in opposite direction of recoil location
         let cosphi: f64 = (phi + PI).cos();
         let sinphi: f64 = (phi + PI).sin();
 

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -236,35 +236,12 @@ impl Particle {
         let cosx: f64 = self.dir.x;
         let cosy: f64 = self.dir.y;
         let cosz: f64 = self.dir.z;
-        let cosphi: f64 = (phi - PI).cos();
-        let sinphi: f64 = (phi - PI).sin();
+        // minus sign here enforces particle deflection in opposite direction of recoil location
+        let cosphi: f64 = (phi + PI).cos();
+        let sinphi: f64 = (phi + PI).sin();
 
         let cpsi: f64 = psi.cos();
         let spsi: f64 = psi.sin();
-
-        // To resolve the singularity, a different set of rotations is used when cosx == -1
-        // Because of this, the recoil location is not consistent between the two formulas at a given phi
-        // Since phi is sampled uniformly from (0, 2pi), this does not matter
-        // However, if a crystalline structure is ever added, this needs to be considered
-        /*
-        let cosx_new = if cosx > -1. {
-            cpsi*cosx - spsi*(cosz*sinphi + cosy*cosphi)
-        } else {
-            cpsi*cosx - spsi*((1. + cosz - cosx*cosx)*cosphi - cosx*cosy*sinphi)/(1. + cosz)
-        };
-
-        let cosy_new = if cosx > -1. {
-            cpsi*cosy + spsi*((1. + cosx - cosy*cosy)*cosphi - cosy*cosz*sinphi)/(1. + cosx)
-        } else {
-            cpsi*cosy + spsi*((1. + cosz - cosy*cosy)*sinphi - cosx*cosy*cosphi)/(1. + cosz)
-        };
-
-        let cosz_new = if cosx > -1. {
-            cpsi*cosz + spsi*((1. + cosx - cosz*cosz)*sinphi - cosy*cosz*cosphi)/(1. + cosx)
-        } else {
-            cpsi*cosz + spsi*(cosx*cosphi + cosy*sinphi)
-        };
-        */
 
         let (e1, e2) = math::duff_orthonormal_basis(self.dir);
         let cosx_new = cpsi*cosx - spsi*(cosphi*e1.x + sinphi*e2.x);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -975,15 +975,15 @@ fn test_momentum_conservation() {
                         println!();
 
                         //These values are in  [angstrom amu / second], so very large.
-                        assert!(approx_eq!(f64, initial_momentum.x/ANGSTROM/AMU, final_momentum.x/ANGSTROM/AMU, epsilon = 1000.));
-                        assert!(approx_eq!(f64, initial_momentum.y/ANGSTROM/AMU, final_momentum.y/ANGSTROM/AMU, epsilon = 1000.));
-                        assert!(approx_eq!(f64, initial_momentum.z/ANGSTROM/AMU, final_momentum.z/ANGSTROM/AMU, epsilon = 1000.));
+                        assert!(approx_eq!(f64, initial_momentum.x/ANGSTROM/AMU, final_momentum.x/ANGSTROM/AMU, epsilon = 10.));
+                        assert!(approx_eq!(f64, initial_momentum.y/ANGSTROM/AMU, final_momentum.y/ANGSTROM/AMU, epsilon = 10.));
+                        assert!(approx_eq!(f64, initial_momentum.z/ANGSTROM/AMU, final_momentum.z/ANGSTROM/AMU, epsilon = 10.));
 
                         assert!(!particle_1.E.is_nan());
                         assert!(!particle_2.E.is_nan());
                         assert!(!initial_momentum.x.is_nan());
-                        assert!(!initial_momentum.x.is_nan());
-                        assert!(!initial_momentum.x.is_nan());
+                        assert!(!initial_momentum.y.is_nan());
+                        assert!(!initial_momentum.z.is_nan());
                     }
                 }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@
 use super::*;
 #[cfg(test)]
 use float_cmp::*;
-
+use rand::RngExt;
 
 #[test]
 #[cfg(feature = "cpr_rootfinder")]
@@ -1002,33 +1002,63 @@ fn test_rotate() {
     let x = 0.;
     let y = 0.;
     let z = 0.;
-    let cosx = (PI/4.).cos();
-    let cosy = (PI/4.).sin();
-    let cosz = 0.;
-    let psi = -PI/4.;
-    let phi = 0.;
+    let cosx = 1.0;
+    let cosy = 0.0;
+    let cosz = 0.0;
+    let psi = PI/4.;
+    let phi = 0.0; // Duff ONB gives e1=(1/2, -1/2, -√2/2) e2=(-1/2, 1/2, -√2/2)
+    // That means in order for the rotation tests to work, we need to re-align the orthoframe
+    // by rotating by a phi of 3 pi / 4.
 
-    let mut particle = particle::Particle::new(mass, Z, E, Ec, Es, Ed, x, y, z, cosx, cosy, cosz, false, false, 0);
+    let mut particle_1 = particle::Particle::new(mass, Z, E, Ec, Es, Ed, x, y, z, cosx, cosy, cosz, false, false, 0);
+    // Check that rotation in 2D works
+    // Duff ONB is not aligned to (x, y, z)
+    particle_1.rotate(psi, phi);
+    assert!(approx_eq!(f64, particle_1.dir.x, (2.0_f64).sqrt()/2., epsilon = 1E-9), "particle_1.dir.x: {} Should be ~√2/2.", particle_1.dir.x);
+    assert!(approx_eq!(f64, particle_1.dir.y, 0., epsilon = 1E-9), "particle.dir.y: {} Should be ~0.", particle_1.dir.y);
+    assert!(approx_eq!(f64, particle_1.dir.z, -(2.0_f64).sqrt()/2., epsilon = 1E-9), "particle_1.dir.z: {} Should be ~-√2/2.", particle_1.dir.z);
 
-    //Check that rotation in 2D works
-    particle.rotate(psi, phi);
-    assert!(approx_eq!(f64, particle.dir.x, 0., epsilon = 1E-12), "particle.dir.x: {} Should be ~0.", particle.dir.x);
-    assert!(approx_eq!(f64, particle.dir.y, 1., epsilon = 1E-12), "particle.dir.y: {} Should be ~1.", particle.dir.y);
+    let mut particle_2 = particle::Particle::new(mass, Z, E, Ec, Es, Ed, x, y, z, cosx, cosy, cosz, false, false, 0);
+    particle_2.rotate(-psi, phi);
+    assert!(approx_eq!(f64, particle_2.dir.x, (2.0_f64).sqrt()/2., epsilon = 1E-9), "particle.dir.x: {} Should be ~√2/2.", particle_2.dir.x);
+    assert!(approx_eq!(f64, particle_2.dir.y, 0., epsilon = 1E-9), "particle.dir.y: {} Should be ~0.", particle_2.dir.y);
+    assert!(approx_eq!(f64, particle_2.dir.z, (2.0_f64).sqrt()/2., epsilon = 1E-9), "particle.dir.z: {} Should be ~-√2/2.", particle_2.dir.z);
 
-    //Check that rotating back by negative psi returns to the previous values
-    particle.rotate(-psi, phi);
-    assert!(approx_eq!(f64, particle.dir.x, cosx, epsilon = 1E-12), "particle.dir.x: {} Should be ~{}", particle.dir.x, cosx);
-    assert!(approx_eq!(f64, particle.dir.y, cosy, epsilon = 1E-12), "particle.dir.y: {} Should be ~{}", particle.dir.y, cosy);
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    for _ in 0..1000 {
+        let cosx: f64 = rng.random();
+        let cosy: f64 = rng.random();
+        let cosz: f64 = rng.random();
+        let random_phi: f64 = rng.random::<f64>()*PI*2.;
+        let mag = (cosx*cosx + cosy*cosy + cosz*cosz).sqrt();
 
-    //Check that azimuthal rotation by 180 degrees works correctly
-    let phi = PI;
-    particle.rotate(psi, phi);
-    assert!(approx_eq!(f64, particle.dir.x, 1., epsilon = 1E-12), "particle.dir.x: {} Should be ~1.", particle.dir.x);
-    assert!(approx_eq!(f64, particle.dir.y, 0., epsilon = 1E-12), "particle.dir.y: {} Should be ~0.", particle.dir.y);
+        // Test that rotating in psi by PI results in backwards travel
+        let mut particle_3 = particle::Particle::new(mass, Z, E, Ec, Es, Ed, x, y, z, cosx, cosy, cosz, false, false, 0);
+        particle_3.rotate(PI, 0.0);
+        assert!(approx_eq!(f64, particle_3.dir.x, -cosx/mag, epsilon = 1e-9), "particle_3.dir.x: {}; Should be {}.", particle_3.dir.x, -cosx/mag);
+        assert!(approx_eq!(f64, particle_3.dir.y, -cosy/mag, epsilon = 1e-9), "particle_3.dir.y: {}; Should be {}.", particle_3.dir.y, -cosy/mag);
+        assert!(approx_eq!(f64, particle_3.dir.z, -cosz/mag, epsilon = 1e-9), "particle_3.dir.z: {}; Should be {}.", particle_3.dir.z, -cosz/mag);
 
-    //Check that particle direction vector remains normalized following rotations
-    assert!(approx_eq!(f64, particle.dir.x.powi(2) + particle.dir.y.powi(2) + particle.dir.z.powi(2), 1.), "Particle direction not normalized.");
+        //Check that azimuthal rotation results in zero direction change
+        let mut particle_4 = particle::Particle::new(mass, Z, E, Ec, Es, Ed, x, y, z, cosx, cosy, cosz, false, false, 0);
+        particle_4.rotate(0.0, random_phi);
+        assert!(approx_eq!(f64, particle_4.dir.x, cosx/mag, epsilon = 1e-9), "particle_4.dir.x: {}; Should be {}.", particle_4.dir.x, cosx/mag);
+        assert!(approx_eq!(f64, particle_4.dir.y, cosy/mag, epsilon = 1e-9), "particle_4.dir.y: {}; Should be {}.", particle_4.dir.y, cosy/mag);
+        assert!(approx_eq!(f64, particle_4.dir.z, cosz/mag, epsilon = 1e-9), "particle_4.dir.z: {}; Should be {}.", particle_4.dir.z, cosz/mag);
 
+        // Check that rotation by random phi and rotation by +/- 45 degrees results in orthogonal directions
+        // If particle_5 is rotated by 45 degrees along the original orthonormal basis, and particle_6 -45, they should be orthogonal after
+        let mut particle_5 = particle::Particle::new(mass, Z, E, Ec, Es, Ed, x, y, z, cosx, cosy, cosz, false, false, 0);
+        particle_5.rotate(PI/4., random_phi);
+        let mut particle_6 = particle::Particle::new(mass, Z, E, Ec, Es, Ed, x, y, z, cosx, cosy, cosz, false, false, 0);
+        particle_6.rotate(-PI/4., random_phi);
+        assert!(approx_eq!(f64, particle_5.dir.dot(&particle_6.dir), 0.0, epsilon=1e-9), "dir_1 dot dir_2 = {}; should be orthogonal.", particle_5.dir.dot(&particle_6.dir));
+
+        //Check that particle direction vector remains normalized following rotations
+        assert!(approx_eq!(f64, particle_4.dir.x.powi(2) + particle_4.dir.y.powi(2) + particle_4.dir.z.powi(2), 1.), "Particle direction not normalized.");
+        assert!(approx_eq!(f64, particle_5.dir.x.powi(2) + particle_5.dir.y.powi(2) + particle_5.dir.z.powi(2), 1.), "Particle direction not normalized.");
+        assert!(approx_eq!(f64, particle_6.dir.x.powi(2) + particle_6.dir.y.powi(2) + particle_6.dir.z.powi(2), 1.), "Particle direction not normalized.");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Thank you for your contribution to rustBCA!

Before submitting this PR, please make sure you have:

- [X] Opened an issue
- [X] Referenced the relevant issue number(s) below
- [X] Provided a description of the changes below
- [X] Ensured all tests pass and added any necessary tests for new code

Fixes #314, #302

## Description
This PR swaps out the custom derived formulas for constructing an orthonormal basis for recoil generation and particle deflection with Duff et al.'s robust formula.

This also rolls in improvements to input validation and rolls-back the electronic stopping change - probably BV stopping needs two different ck for each energy regime? 

## Tests
`cargo test` passes with modification to tests.rs for the new orthonormal bases; `test_cube.py` reproduces the correct behavior. Other results all seem identical within statistical error.

This will break the seeded rng tests.